### PR TITLE
fix: Remove tag display from build info in AppFooter

### DIFF
--- a/src/components/common/AppFooter.tsx
+++ b/src/components/common/AppFooter.tsx
@@ -57,8 +57,7 @@ export default function AppFooter() {
 
           <Stack alignItems="center" direction="row" spacing={1.25}>
             <Typography component="p" variant="caption">
-              Version {buildInfo.version} · {buildInfo.tag} · {buildInfo.commit} · Built{" "}
-              {buildInfo.buildDate}
+              Version {buildInfo.version} · {buildInfo.commit} · Built {buildInfo.buildDate}
             </Typography>
             <Tooltip title="Open Ventry on GitHub">
               <IconButton


### PR DESCRIPTION
## Summary

## Testing

<!-- ventry:auto-fixes:start -->
Fixes #61
<!-- ventry:auto-fixes:end -->
