### PR TITLE
72 Add event badge designer and printing workflow

### DIFF
--- a/prisma/migrations/20260612120000_add_badge_templates/migration.sql
+++ b/prisma/migrations/20260612120000_add_badge_templates/migration.sql
@@ -1,0 +1,21 @@
+CREATE TABLE "BadgeTemplate" (
+    "id" TEXT NOT NULL,
+    "eventId" INTEGER NOT NULL,
+    "name" TEXT NOT NULL,
+    "isDefault" BOOLEAN NOT NULL DEFAULT false,
+    "widthMm" DOUBLE PRECISION NOT NULL DEFAULT 85,
+    "heightMm" DOUBLE PRECISION NOT NULL DEFAULT 55,
+    "background" JSONB NOT NULL DEFAULT '{}',
+    "elements" JSONB NOT NULL DEFAULT '[]',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "BadgeTemplate_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "BadgeTemplate_eventId_idx" ON "BadgeTemplate"("eventId");
+CREATE INDEX "BadgeTemplate_eventId_isDefault_idx" ON "BadgeTemplate"("eventId", "isDefault");
+
+ALTER TABLE "BadgeTemplate"
+ADD CONSTRAINT "BadgeTemplate_eventId_fkey"
+FOREIGN KEY ("eventId") REFERENCES "Event"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -140,12 +140,30 @@ model Event {
   requiresHotel       Boolean         @default(false)
   requireApproval     Boolean         @default(false)
   scanOnce            Boolean         @default(false)
+  badgeTemplates      BadgeTemplate[]
   owner               Admin?          @relation(fields: [ownerId], references: [id])
   checkInLogs         RegistrationCheckInLog[]
   location            Location?
   products            Product[]
   registrations       Registration[]
   supportTickets      SupportTicket[]
+}
+
+model BadgeTemplate {
+  id         String   @id @default(cuid())
+  eventId    Int
+  name       String
+  isDefault  Boolean  @default(false)
+  widthMm    Float    @default(85)
+  heightMm   Float    @default(55)
+  background Json     @default("{}")
+  elements   Json     @default("[]")
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+  event      Event    @relation(fields: [eventId], references: [id], onDelete: Cascade)
+
+  @@index([eventId])
+  @@index([eventId, isDefault])
 }
 
 model Location {

--- a/src/app/admin/billing/page.tsx
+++ b/src/app/admin/billing/page.tsx
@@ -197,16 +197,12 @@ export default async function AdminBillingPage() {
             </Typography>
             <Grid container spacing={2} alignItems="stretch">
                 <Suspense
-                    fallback={
-                        <>
-                            {Array.from({ length: 6 }).map((_, i) => (
-                                // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton list
-                                <Grid key={i} size={{ xs: 12, sm: 6, md: 3 }}>
-                                    <Skeleton variant="rounded" height={110} />
-                                </Grid>
-                            ))}
-                        </>
-                    }
+                    fallback={Array.from({ length: 6 }).map((_, i) => (
+                        // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton list
+                        <Grid key={i} size={{ xs: 12, sm: 6, md: 3 }}>
+                            <Skeleton variant="rounded" height={110} />
+                        </Grid>
+                    ))}
                 >
                     <BillingContent />
                 </Suspense>

--- a/src/app/admin/events/[id]/EditEventClient.tsx
+++ b/src/app/admin/events/[id]/EditEventClient.tsx
@@ -3,11 +3,11 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import EventForm from '@/components/admin/events/EventForm';
-import { type AdminCreateEventInput } from '@/types/schemas/event/admin';
+import type { AdminCreateEventInput } from '@/types/schemas/event/admin';
 import { Box } from '@mui/material';
-import { type SerializedEvent } from '@/types/event';
+import type { SerializedEvent } from '@/types/event';
 
-import { type InitialData } from '@/components/admin/events/EventForm';
+import type { InitialData } from '@/components/admin/events/EventForm';
 
 interface EditEventClientProps {
   event: SerializedEvent;

--- a/src/app/admin/events/[id]/badges/page.tsx
+++ b/src/app/admin/events/[id]/badges/page.tsx
@@ -1,0 +1,74 @@
+import { notFound, redirect } from "next/navigation";
+import BadgeDesigner from "@/components/admin/badges/BadgeDesigner";
+import { checkEventAdminAuth } from "@/lib/auth/event-admin";
+import { DEFAULT_BADGE_TEMPLATE, normalizeBadgeTemplate } from "@/lib/badges/badge";
+import { loadBadgeAttendees } from "@/lib/badges/server";
+import { prisma } from "@/lib/prisma/prisma";
+
+type CustomFieldOption = {
+  id: string;
+  label: string;
+};
+
+function normalizeCustomFields(raw: unknown): CustomFieldOption[] {
+  if (!Array.isArray(raw)) return [];
+
+  return raw.flatMap((field) => {
+    if (!field || typeof field !== "object") return [];
+    const candidate = field as { id?: unknown; label?: unknown };
+    if (typeof candidate.id !== "string" || typeof candidate.label !== "string") return [];
+    return [{ id: candidate.id, label: candidate.label }];
+  });
+}
+
+export default async function AdminEventBadgesPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const eventId = Number((await params).id);
+  if (Number.isNaN(eventId)) notFound();
+
+  const authResult = await checkEventAdminAuth(eventId);
+  if (!authResult.authorized) {
+    redirect("/login?callbackUrl=/admin/events");
+  }
+
+  const [event, templates, attendees] = await Promise.all([
+    prisma.event.findUnique({
+      where: { id: eventId },
+      select: {
+        id: true,
+        name: true,
+        customFields: true,
+        products: {
+          where: { type: "TICKET" },
+          orderBy: { order: "asc" },
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+      },
+    }),
+    prisma.badgeTemplate.findMany({
+      where: { eventId },
+      orderBy: [{ isDefault: "desc" }, { updatedAt: "desc" }],
+    }),
+    loadBadgeAttendees(eventId, { status: "CONFIRMED" }),
+  ]);
+
+  if (!event) notFound();
+
+  return (
+    <BadgeDesigner
+      eventId={event.id}
+      eventName={event.name}
+      initialTemplates={templates.map(normalizeBadgeTemplate)}
+      fallbackTemplate={{ ...DEFAULT_BADGE_TEMPLATE, name: `${event.name} Badge` }}
+      initialAttendees={attendees}
+      ticketTiers={event.products}
+      customFields={normalizeCustomFields(event.customFields)}
+    />
+  );
+}

--- a/src/app/admin/events/create/page.tsx
+++ b/src/app/admin/events/create/page.tsx
@@ -3,7 +3,7 @@
 import { Suspense, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import EventForm from '@/components/admin/events/EventForm';
-import { type AdminCreateEventInput } from '@/types/schemas/event/admin';
+import type { AdminCreateEventInput } from '@/types/schemas/event/admin';
 import { Box } from '@mui/material';
 import PageLoadingState from '@/components/common/PageLoadingState';
 

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -148,14 +148,10 @@ export default async function AdminDashboardPage() {
             </Typography>
             <Grid container spacing={2} alignItems="stretch">
                 <Suspense
-                    fallback={
-                        <>
-                            {Array.from({ length: 7 }).map((_, i) => (
-                                // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton list
-                                <StatSkeleton key={i} />
-                            ))}
-                        </>
-                    }
+                    fallback={Array.from({ length: 7 }).map((_, i) => (
+                        // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton list
+                        <StatSkeleton key={i} />
+                    ))}
                 >
                     <DashboardStats />
                 </Suspense>

--- a/src/app/api/admin/event/[id]/badge-templates/[templateId]/route.test.ts
+++ b/src/app/api/admin/event/[id]/badge-templates/[templateId]/route.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/auth/event-admin", () => ({
+  checkEventAdminAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma/prisma", () => ({
+  prisma: {
+    badgeTemplate: {
+      updateMany: vi.fn(),
+      findFirst: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  },
+}));
+
+import * as badgeTemplateRoute from "@/app/api/admin/event/[id]/badge-templates/[templateId]/route";
+import { checkEventAdminAuth } from "@/lib/auth/event-admin";
+import { prisma } from "@/lib/prisma/prisma";
+
+const mockedCheckEventAdminAuth = checkEventAdminAuth as unknown as ReturnType<typeof vi.fn>;
+const mockedUpdateMany = prisma.badgeTemplate.updateMany as unknown as ReturnType<typeof vi.fn>;
+const mockedFindFirst = prisma.badgeTemplate.findFirst as unknown as ReturnType<typeof vi.fn>;
+const mockedDeleteMany = prisma.badgeTemplate.deleteMany as unknown as ReturnType<typeof vi.fn>;
+const mockedTransaction = prisma.$transaction as unknown as ReturnType<typeof vi.fn>;
+
+function request(method: string, url: string, body?: unknown) {
+  return new NextRequest(url, {
+    method,
+    headers: body ? { "content-type": "application/json" } : undefined,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+function templateRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "template-1",
+    eventId: 7,
+    name: "Updated Badge",
+    isDefault: true,
+    widthMm: 85,
+    heightMm: 55,
+    background: { color: "#ffffff", fit: "cover", positionX: 50, positionY: 50 },
+    elements: [],
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-02T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+describe("App Router: /api/admin/event/[id]/badge-templates/[templateId]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedCheckEventAdminAuth.mockResolvedValue({ authorized: true, adminId: "admin-1" });
+    mockedTransaction.mockImplementation(callback => callback(prisma));
+  });
+
+  it("updates only a template belonging to the route event", async () => {
+    mockedUpdateMany.mockResolvedValueOnce({ count: 1 }).mockResolvedValueOnce({ count: 2 });
+    mockedFindFirst.mockResolvedValue(templateRow());
+
+    const response = await badgeTemplateRoute.PATCH(
+      request("PATCH", "http://localhost/api/admin/event/7/badge-templates/template-1", {
+        name: "Updated Badge",
+        isDefault: true,
+      }),
+      { params: Promise.resolve({ id: "7", templateId: "template-1" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockedUpdateMany).toHaveBeenNthCalledWith(1, {
+      where: { id: "template-1", eventId: 7 },
+      data: {
+        name: "Updated Badge",
+        isDefault: true,
+      },
+    });
+    expect(mockedUpdateMany).toHaveBeenNthCalledWith(2, {
+      where: { eventId: 7, id: { not: "template-1" } },
+      data: { isDefault: false },
+    });
+    expect(mockedFindFirst).toHaveBeenCalledWith({
+      where: { id: "template-1", eventId: 7 },
+    });
+  });
+
+  it("returns 404 instead of updating when the template belongs to another event", async () => {
+    mockedUpdateMany.mockResolvedValue({ count: 0 });
+
+    const response = await badgeTemplateRoute.PATCH(
+      request("PATCH", "http://localhost/api/admin/event/7/badge-templates/template-from-event-8", {
+        name: "Nope",
+      }),
+      { params: Promise.resolve({ id: "7", templateId: "template-from-event-8" }) },
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "Badge template not found" });
+    expect(mockedUpdateMany).toHaveBeenCalledTimes(1);
+    expect(mockedUpdateMany).toHaveBeenCalledWith({
+      where: { id: "template-from-event-8", eventId: 7 },
+      data: { name: "Nope" },
+    });
+    expect(mockedFindFirst).not.toHaveBeenCalled();
+  });
+
+  it("deletes only a template belonging to the route event", async () => {
+    mockedDeleteMany.mockResolvedValue({ count: 1 });
+
+    const response = await badgeTemplateRoute.DELETE(
+      request("DELETE", "http://localhost/api/admin/event/7/badge-templates/template-1"),
+      { params: Promise.resolve({ id: "7", templateId: "template-1" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockedDeleteMany).toHaveBeenCalledWith({
+      where: { id: "template-1", eventId: 7 },
+    });
+  });
+
+  it("returns 404 instead of deleting when the template belongs to another event", async () => {
+    mockedDeleteMany.mockResolvedValue({ count: 0 });
+
+    const response = await badgeTemplateRoute.DELETE(
+      request("DELETE", "http://localhost/api/admin/event/7/badge-templates/template-from-event-8"),
+      { params: Promise.resolve({ id: "7", templateId: "template-from-event-8" }) },
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "Badge template not found" });
+    expect(mockedDeleteMany).toHaveBeenCalledWith({
+      where: { id: "template-from-event-8", eventId: 7 },
+    });
+  });
+});

--- a/src/app/api/admin/event/[id]/badge-templates/[templateId]/route.ts
+++ b/src/app/api/admin/event/[id]/badge-templates/[templateId]/route.ts
@@ -1,0 +1,88 @@
+import { type NextRequest, NextResponse } from "next/server";
+import type { Prisma } from "@/generated/prisma";
+import { checkEventAdminAuth } from "@/lib/auth/event-admin";
+import { prisma } from "@/lib/prisma/prisma";
+import { normalizeBadgeTemplate } from "@/lib/badges/badge";
+import { badgeTemplatePatchSchema } from "@/types/schemas/badge";
+import { z } from "zod";
+
+async function authorize(eventId: number, request: NextRequest) {
+  const authResult = await checkEventAdminAuth(eventId, request.headers);
+  if (!authResult.authorized) {
+    return NextResponse.json({ error: authResult.error || "Forbidden" }, { status: 403 });
+  }
+
+  return null;
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string; templateId: string }> },
+) {
+  try {
+    const { id, templateId } = await params;
+    const eventId = Number(id);
+    if (Number.isNaN(eventId)) return NextResponse.json({ error: "Invalid ID" }, { status: 400 });
+
+    const forbidden = await authorize(eventId, req);
+    if (forbidden) return forbidden;
+
+    const body = await req.json();
+    const data = badgeTemplatePatchSchema.parse(body);
+
+    const template = await prisma.$transaction(async (tx) => {
+      const result = await tx.badgeTemplate.updateMany({
+        where: { id: templateId, eventId },
+        data: {
+          ...(data.name !== undefined && { name: data.name }),
+          ...(data.isDefault !== undefined && { isDefault: data.isDefault }),
+          ...(data.widthMm !== undefined && { widthMm: data.widthMm }),
+          ...(data.heightMm !== undefined && { heightMm: data.heightMm }),
+          ...(data.background !== undefined && { background: data.background as Prisma.InputJsonValue }),
+          ...(data.elements !== undefined && { elements: data.elements as Prisma.InputJsonValue }),
+        },
+      });
+
+      if (result.count === 0) return null;
+
+      if (data.isDefault) {
+        await tx.badgeTemplate.updateMany({
+          where: { eventId, id: { not: templateId } },
+          data: { isDefault: false },
+        });
+      }
+
+      return tx.badgeTemplate.findFirst({
+        where: { id: templateId, eventId },
+      });
+    });
+
+    if (!template) return NextResponse.json({ error: "Badge template not found" }, { status: 404 });
+
+    return NextResponse.json({ template: normalizeBadgeTemplate(template) }, { status: 200 });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: error.issues }, { status: 422 });
+    }
+
+    console.error("Error updating badge template:", error);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string; templateId: string }> },
+) {
+  const { id, templateId } = await params;
+  const eventId = Number(id);
+  if (Number.isNaN(eventId)) return NextResponse.json({ error: "Invalid ID" }, { status: 400 });
+
+  const forbidden = await authorize(eventId, req);
+  if (forbidden) return forbidden;
+
+  const result = await prisma.badgeTemplate.deleteMany({ where: { id: templateId, eventId } });
+  if (result.count === 0) return NextResponse.json({ error: "Badge template not found" }, { status: 404 });
+
+  return NextResponse.json({ message: "Badge template deleted" }, { status: 200 });
+}

--- a/src/app/api/admin/event/[id]/badge-templates/route.test.ts
+++ b/src/app/api/admin/event/[id]/badge-templates/route.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/auth/event-admin", () => ({
+  checkEventAdminAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma/prisma", () => ({
+  prisma: {
+    badgeTemplate: {
+      findMany: vi.fn(),
+      create: vi.fn(),
+      updateMany: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  },
+}));
+
+import * as badgeTemplatesRoute from "@/app/api/admin/event/[id]/badge-templates/route";
+import { checkEventAdminAuth } from "@/lib/auth/event-admin";
+import { prisma } from "@/lib/prisma/prisma";
+
+const mockedCheckEventAdminAuth = checkEventAdminAuth as unknown as ReturnType<typeof vi.fn>;
+const mockedFindMany = prisma.badgeTemplate.findMany as unknown as ReturnType<typeof vi.fn>;
+const mockedCreate = prisma.badgeTemplate.create as unknown as ReturnType<typeof vi.fn>;
+const mockedUpdateMany = prisma.badgeTemplate.updateMany as unknown as ReturnType<typeof vi.fn>;
+const mockedTransaction = prisma.$transaction as unknown as ReturnType<typeof vi.fn>;
+
+function request(method: string, url: string, body?: unknown) {
+  return new NextRequest(url, {
+    method,
+    headers: body ? { "content-type": "application/json" } : undefined,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+function templateRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "template-1",
+    eventId: 7,
+    name: "Staff Badge",
+    isDefault: false,
+    widthMm: 85,
+    heightMm: 55,
+    background: { color: "#ffffff", fit: "cover", positionX: 50, positionY: 50 },
+    elements: [],
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-02T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function templateInput(overrides: Record<string, unknown> = {}) {
+  return {
+    name: "Staff Badge",
+    isDefault: true,
+    widthMm: 85,
+    heightMm: 55,
+    background: { color: "#ffffff", fit: "cover", positionX: 50, positionY: 50 },
+    elements: [],
+    ...overrides,
+  };
+}
+
+describe("App Router: /api/admin/event/[id]/badge-templates", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedCheckEventAdminAuth.mockResolvedValue({ authorized: true, adminId: "admin-1" });
+    mockedTransaction.mockImplementation(callback => callback(prisma));
+  });
+
+  it("lists only templates for the authorized event", async () => {
+    mockedFindMany.mockResolvedValue([templateRow()]);
+
+    const response = await badgeTemplatesRoute.GET(
+      request("GET", "http://localhost/api/admin/event/7/badge-templates"),
+      { params: Promise.resolve({ id: "7" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockedCheckEventAdminAuth).toHaveBeenCalledWith(7, expect.any(Headers));
+    expect(mockedFindMany).toHaveBeenCalledWith({
+      where: { eventId: 7 },
+      orderBy: [{ isDefault: "desc" }, { updatedAt: "desc" }],
+    });
+  });
+
+  it("does not list templates when the event admin check fails", async () => {
+    mockedCheckEventAdminAuth.mockResolvedValue({ authorized: false, error: "Only this event's admin can manage this event" });
+
+    const response = await badgeTemplatesRoute.GET(
+      request("GET", "http://localhost/api/admin/event/7/badge-templates"),
+      { params: Promise.resolve({ id: "7" }) },
+    );
+
+    expect(response.status).toBe(403);
+    expect(mockedFindMany).not.toHaveBeenCalled();
+  });
+
+  it("creates templates under the route event and clears defaults only for that event", async () => {
+    mockedCreate.mockResolvedValue(templateRow({ isDefault: true }));
+
+    const response = await badgeTemplatesRoute.POST(
+      request("POST", "http://localhost/api/admin/event/7/badge-templates", templateInput()),
+      { params: Promise.resolve({ id: "7" }) },
+    );
+
+    expect(response.status).toBe(201);
+    expect(mockedUpdateMany).toHaveBeenCalledWith({
+      where: { eventId: 7 },
+      data: { isDefault: false },
+    });
+    expect(mockedCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        eventId: 7,
+        name: "Staff Badge",
+        isDefault: true,
+      }),
+    });
+  });
+});

--- a/src/app/api/admin/event/[id]/badge-templates/route.ts
+++ b/src/app/api/admin/event/[id]/badge-templates/route.ts
@@ -1,0 +1,71 @@
+import { type NextRequest, NextResponse } from "next/server";
+import type { Prisma } from "@/generated/prisma";
+import { checkEventAdminAuth } from "@/lib/auth/event-admin";
+import { prisma } from "@/lib/prisma/prisma";
+import { normalizeBadgeTemplate } from "@/lib/badges/badge";
+import { badgeTemplateInputSchema } from "@/types/schemas/badge";
+import { z } from "zod";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const eventId = Number((await params).id);
+  if (Number.isNaN(eventId)) return NextResponse.json({ error: "Invalid ID" }, { status: 400 });
+
+  const authResult = await checkEventAdminAuth(eventId, req.headers);
+  if (!authResult.authorized) return NextResponse.json({ error: authResult.error || "Forbidden" }, { status: 403 });
+
+  const templates = await prisma.badgeTemplate.findMany({
+    where: { eventId },
+    orderBy: [{ isDefault: "desc" }, { updatedAt: "desc" }],
+  });
+
+  return NextResponse.json({ templates: templates.map(normalizeBadgeTemplate) }, { status: 200 });
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const eventId = Number((await params).id);
+    if (Number.isNaN(eventId)) return NextResponse.json({ error: "Invalid ID" }, { status: 400 });
+
+    const authResult = await checkEventAdminAuth(eventId, req.headers);
+    if (!authResult.authorized) return NextResponse.json({ error: authResult.error || "Forbidden" }, { status: 403 });
+
+    const body = await req.json();
+    const data = badgeTemplateInputSchema.parse(body);
+
+    const template = await prisma.$transaction(async (tx) => {
+      if (data.isDefault) {
+        await tx.badgeTemplate.updateMany({
+          where: { eventId },
+          data: { isDefault: false },
+        });
+      }
+
+      return tx.badgeTemplate.create({
+        data: {
+          eventId,
+          name: data.name,
+          isDefault: data.isDefault,
+          widthMm: data.widthMm,
+          heightMm: data.heightMm,
+          background: data.background as Prisma.InputJsonValue,
+          elements: data.elements as Prisma.InputJsonValue,
+        },
+      });
+    });
+
+    return NextResponse.json({ template: normalizeBadgeTemplate(template) }, { status: 201 });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: error.issues }, { status: 422 });
+    }
+
+    console.error("Error creating badge template:", error);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/event/[id]/badges/attendees/route.ts
+++ b/src/app/api/admin/event/[id]/badges/attendees/route.ts
@@ -1,0 +1,35 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { checkEventAdminAuth } from "@/lib/auth/event-admin";
+import { loadBadgeAttendees } from "@/lib/badges/server";
+import { badgeAttendeeQuerySchema } from "@/types/schemas/badge";
+import { z } from "zod";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const eventId = Number((await params).id);
+    if (Number.isNaN(eventId)) return NextResponse.json({ error: "Invalid ID" }, { status: 400 });
+
+    const authResult = await checkEventAdminAuth(eventId, req.headers);
+    if (!authResult.authorized) return NextResponse.json({ error: authResult.error || "Forbidden" }, { status: 403 });
+
+    const url = new URL(req.url);
+    const query = badgeAttendeeQuerySchema.parse({
+      status: url.searchParams.get("status") || "CONFIRMED",
+      ticketTier: url.searchParams.get("ticketTier") || undefined,
+      search: url.searchParams.get("search") || undefined,
+    });
+
+    const attendees = await loadBadgeAttendees(eventId, query);
+    return NextResponse.json({ attendees }, { status: 200 });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: error.issues }, { status: 422 });
+    }
+
+    console.error("Error listing badge attendees:", error);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/event/[id]/badges/export/route.ts
+++ b/src/app/api/admin/event/[id]/badges/export/route.ts
@@ -1,0 +1,58 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { checkEventAdminAuth } from "@/lib/auth/event-admin";
+import { loadBadgeAttendeesByIds, renderBadgePng, renderPrintableBadgesHtml } from "@/lib/badges/server";
+import { badgeExportSchema } from "@/types/schemas/badge";
+import { z } from "zod";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const eventId = Number((await params).id);
+    if (Number.isNaN(eventId)) return NextResponse.json({ error: "Invalid ID" }, { status: 400 });
+
+    const authResult = await checkEventAdminAuth(eventId, req.headers);
+    if (!authResult.authorized) return NextResponse.json({ error: authResult.error || "Forbidden" }, { status: 403 });
+
+    const body = await req.json();
+    const data = badgeExportSchema.parse(body);
+    const attendees = await loadBadgeAttendeesByIds(eventId, data.attendeeIds);
+
+    if (attendees.length === 0) {
+      return NextResponse.json({ error: "No matching attendees found" }, { status: 404 });
+    }
+
+    if (data.format === "png") {
+      if (attendees.length !== 1) {
+        return NextResponse.json({ error: "PNG export supports one attendee at a time" }, { status: 422 });
+      }
+
+      const png = await renderBadgePng(data.template, attendees[0], eventId);
+      const body = png.buffer.slice(png.byteOffset, png.byteOffset + png.byteLength) as ArrayBuffer;
+      return new NextResponse(body, {
+        status: 200,
+        headers: {
+          "Content-Type": "image/png",
+          "Content-Disposition": `attachment; filename="badge-${attendees[0].ticketId}.png"`,
+        },
+      });
+    }
+
+    const html = renderPrintableBadgesHtml(data.template, attendees, eventId, data.pageMode);
+    return new NextResponse(html, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/html; charset=utf-8",
+        "Content-Disposition": "inline; filename=\"badges.html\"",
+      },
+    });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: error.issues }, { status: 422 });
+    }
+
+    console.error("Error exporting badges:", error);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/event/[id]/route.ts
+++ b/src/app/api/admin/event/[id]/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma/prisma";
-import { Prisma } from "@/generated/prisma";
+import type { Prisma } from "@/generated/prisma";
 import { checkAdminAuth, forbiddenResponse } from "@/lib/auth/admin";
 import { adminUpdateEventSchema } from "@/types/schemas/event/admin";
 import { z } from "zod";

--- a/src/app/api/admin/media/upload/route.ts
+++ b/src/app/api/admin/media/upload/route.ts
@@ -14,6 +14,7 @@ export async function POST(req: NextRequest) {
         // 2. Parse Form Data
         const formData = await req.formData();
         const file = formData.get("file") as File | null;
+        const mode = formData.get("mode") === "badge-photo" ? "badge-photo" : "banner";
 
         if (!file) {
             return NextResponse.json({ error: "No file uploaded" }, { status: 400 });
@@ -22,12 +23,12 @@ export async function POST(req: NextRequest) {
         // 3. Process with Sharp
         const bytes = Buffer.from(await file.arrayBuffer());
         const processedBuffer = await sharp(bytes)
-            .resize(1200, 630, { fit: 'cover' }) // Standard OpenGraph / Banner size
+            .resize(mode === "badge-photo" ? 900 : 1200, mode === "badge-photo" ? 900 : 630, { fit: 'cover' })
             .toFormat('jpeg', { quality: 75 })
             .toBuffer();
 
         // 4. Upload to Supabase
-        const fileName = `event-${Date.now()}-${Math.random().toString(36).substring(7)}.jpg`;
+        const fileName = `${mode === "badge-photo" ? "badge-photo" : "event"}-${Date.now()}-${Math.random().toString(36).substring(7)}.jpg`;
         const uploadResult = await uploadEventImage(processedBuffer, fileName);
 
         // 5. Get Signed URL (valid for 1 year for banners, or just return path if public)

--- a/src/app/api/admin/stripe/connect/route.ts
+++ b/src/app/api/admin/stripe/connect/route.ts
@@ -2,7 +2,7 @@ import { type NextRequest, NextResponse } from "next/server";
 import { checkAdminAuth, forbiddenResponse } from "@/lib/auth/admin";
 import { stripe } from "@/lib/stripe";
 import { prisma } from "@/lib/prisma/prisma";
-import Stripe from "stripe";
+import type Stripe from "stripe";
 
 export async function POST(_req: NextRequest) {
     try {

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { stripe } from "@/lib/stripe";
 import { prisma } from "@/lib/prisma/prisma";
-import Stripe from "stripe";
+import type Stripe from "stripe";
 
 export async function POST(req: NextRequest) {
   const body = await req.text();
@@ -22,7 +22,7 @@ export async function POST(req: NextRequest) {
 
   try {
     switch (event.type) {
-      case "payment_intent.succeeded":
+      case "payment_intent.succeeded": {
         const paymentIntent = event.data.object as Stripe.PaymentIntent;
         const paymentId = paymentIntent.metadata.paymentId;
         const registrationId = paymentIntent.metadata.registrationId;
@@ -43,6 +43,7 @@ export async function POST(req: NextRequest) {
           ]);
         }
         break;
+      }
       
       // Handle other events like payment_intent.payment_failed if needed
       default:

--- a/src/app/events/[id]/register/RegistrationWizard.tsx
+++ b/src/app/events/[id]/register/RegistrationWizard.tsx
@@ -23,7 +23,7 @@ import {
   MenuItem
 } from '@mui/material';
 import { useRouter } from 'next/navigation';
-import { type SerializedProduct, type SerializedStayPolicy } from '@/types/event';
+import type { SerializedProduct, SerializedStayPolicy } from '@/types/event';
 import { Elements } from '@stripe/react-stripe-js';
 import { stripePromise } from '@/lib/stripeClient';
 import PaymentForm from '@/components/events/registration/PaymentForm';

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,8 +9,8 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: Arial, Helvetica, sans-serif;
+  --font-mono: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,22 +1,11 @@
 import { AppRouterCacheProvider } from "@mui/material-nextjs/v16-appRouter";
 import InitColorSchemeScript from "@mui/material/InitColorSchemeScript";
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import { Suspense } from "react";
 import { Providers } from "./providers";
 import AppFooter from "@/components/common/AppFooter";
 import AppHeader from "@/components/common/AppHeader/AppHeader";
 import "./globals.css";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -32,7 +21,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className="antialiased"
         style={{ display: "flex", flexDirection: "column", minHeight: "100vh" }}
       >
         <InitColorSchemeScript attribute="class" />

--- a/src/app/payment/status/page.tsx
+++ b/src/app/payment/status/page.tsx
@@ -128,8 +128,8 @@ function PaymentStatusContent() {
                   <Typography color="text.secondary">Amount to Transfer:</Typography>
                   <Typography fontWeight="bold" variant="h6">{(status.amount / 100).toFixed(2)} {status.currency.toUpperCase()}</Typography>
                 </Box>
-                {bankInstructions.financial_addresses?.map((addr, idx: number) => (
-                  <Box key={idx} sx={{ mt: 1 }}>
+                {bankInstructions.financial_addresses?.map((addr) => (
+                  <Box key={addr.iban?.iban || addr.iban?.bic || addr.iban?.account_holder_name} sx={{ mt: 1 }}>
                     {addr.iban && (
                       <>
                         <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>

--- a/src/app/stripe/success/page.tsx
+++ b/src/app/stripe/success/page.tsx
@@ -36,7 +36,7 @@ async function SuccessContent({ searchParams }: { searchParams: Promise<{ sessio
 
   if (status === 'complete') {
     return (
-      <section id="success">
+      <section>
         <p>
           We appreciate your business! A confirmation email will be sent to{' '}
           {customerEmail}. If you have any questions, please email{' '}

--- a/src/components/admin/badges/BadgeDesigner.tsx
+++ b/src/components/admin/badges/BadgeDesigner.tsx
@@ -1,0 +1,1073 @@
+"use client";
+
+import { type ChangeEvent, type CSSProperties, type ElementType, useMemo, useRef, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Checkbox,
+  Chip,
+  CircularProgress,
+  Divider,
+  FormControlLabel,
+  Grid,
+  IconButton,
+  MenuItem,
+  Paper,
+  Slider,
+  Stack,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import {
+  Add,
+  ContentCopy,
+  CropSquare,
+  Delete,
+  Download,
+  HorizontalRule,
+  Image as ImageIcon,
+  KeyboardArrowDown,
+  KeyboardArrowUp,
+  Print,
+  RadioButtonUnchecked,
+  Save,
+} from "@mui/icons-material";
+import Image from "next/image";
+import QRCode from "react-qr-code";
+import ImageCropper from "@/components/profile/ImageCropper";
+import { attendeeInitials, fitBadgeText, getBadgeElementValue, getBadgePhotoUrl, type BadgeAttendee, type BadgeTemplate } from "@/lib/badges/badge";
+import type { BadgeElement, BadgeFieldKey, BadgeTemplateInput } from "@/types/schemas/badge";
+
+type TicketTier = {
+  id: string;
+  name: string;
+};
+
+type CustomField = {
+  id: string;
+  label: string;
+};
+
+type PendingFallbackPhoto = {
+  name: string;
+  src: string;
+};
+
+type BadgeDesignerProps = {
+  eventId: number;
+  eventName: string;
+  initialTemplates: BadgeTemplate[];
+  fallbackTemplate: BadgeTemplateInput;
+  initialAttendees: BadgeAttendee[];
+  ticketTiers: TicketTier[];
+  customFields: CustomField[];
+};
+
+const FIELD_OPTIONS: Array<{ value: BadgeFieldKey; label: string }> = [
+  { value: "photo", label: "Photo" },
+  { value: "displayName", label: "Display name" },
+  { value: "legalName", label: "Legal name" },
+  { value: "ticketId", label: "Ticket number" },
+  { value: "ticketTier", label: "Ticket tier" },
+  { value: "eventName", label: "Event name" },
+  { value: "qrCode", label: "QR code" },
+  { value: "customField", label: "Custom field" },
+  { value: "staticText", label: "Static text" },
+];
+
+const SHAPE_OPTIONS: Array<{ value: BadgeFieldKey; label: string; icon: ElementType }> = [
+  { value: "rectangle", label: "Rectangle", icon: CropSquare },
+  { value: "ellipse", label: "Ellipse", icon: RadioButtonUnchecked },
+  { value: "line", label: "Line", icon: HorizontalRule },
+];
+
+const TYPE_OPTIONS = [...FIELD_OPTIONS, ...SHAPE_OPTIONS];
+const SHAPE_TYPES = new Set<BadgeFieldKey>(["rectangle", "ellipse", "line"]);
+
+function isShapeElement(element: BadgeElement) {
+  return SHAPE_TYPES.has(element.type);
+}
+
+function colorInputValue(value: string | undefined, fallback: string) {
+  return value && /^#[0-9a-f]{6}$/i.test(value) ? value : fallback;
+}
+
+function parseCustomCss(customCss: string | undefined): CSSProperties {
+  if (!customCss?.trim()) return {};
+
+  return Object.fromEntries(
+    customCss
+      .split(";")
+      .map(rule => {
+        const separator = rule.indexOf(":");
+        if (separator === -1) return null;
+        const rawProperty = rule.slice(0, separator).trim();
+        const value = rule.slice(separator + 1).trim();
+        if (!rawProperty || !value) return null;
+        const property = rawProperty.replace(/-([a-z])/g, (_, char: string) => char.toUpperCase());
+        return [property, value];
+      })
+      .filter((entry): entry is [string, string] => Boolean(entry)),
+  ) as CSSProperties;
+}
+
+function createElement(type: BadgeFieldKey): BadgeElement {
+  const shape = SHAPE_TYPES.has(type);
+  return {
+    id: `element-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    type,
+    label: TYPE_OPTIONS.find(option => option.value === type)?.label || "Element",
+    x: 10,
+    y: 10,
+    width: type === "photo" || type === "qrCode" ? 22 : type === "ellipse" ? 30 : 42,
+    height: type === "photo" ? 34 : type === "qrCode" ? 22 : type === "line" ? 2 : type === "ellipse" ? 18 : 10,
+    fontSize: type === "eventName" ? 10 : 14,
+    fontWeight: type === "displayName" ? "700" : "600",
+    color: shape ? "#2563eb" : "#111827",
+    align: type === "qrCode" || type === "photo" ? "center" : "left",
+    staticText: type === "staticText" ? "Text" : undefined,
+    shape: "square",
+    backgroundColor: shape ? "#2563eb" : undefined,
+    borderColor: shape ? "#1d4ed8" : undefined,
+    borderWidth: type === "rectangle" || type === "ellipse" ? 1 : 0,
+  };
+}
+
+function templateToDraft(template: BadgeTemplate | BadgeTemplateInput): BadgeTemplateInput {
+  return {
+    name: template.name,
+    isDefault: template.isDefault,
+    widthMm: template.widthMm,
+    heightMm: template.heightMm,
+    background: template.background,
+    elements: template.elements,
+  };
+}
+
+function getErrorMessage(raw: unknown, fallback: string) {
+  if (!raw || typeof raw !== "object") return fallback;
+  const payload = raw as { error?: string | Array<{ message?: string }> };
+  if (typeof payload.error === "string") return payload.error;
+  if (Array.isArray(payload.error)) return payload.error[0]?.message || fallback;
+  return fallback;
+}
+
+export default function BadgeDesigner({
+  eventId,
+  eventName,
+  initialTemplates,
+  fallbackTemplate,
+  initialAttendees,
+  ticketTiers,
+  customFields,
+}: BadgeDesignerProps) {
+  const initialTemplate = initialTemplates[0] || {
+    ...fallbackTemplate,
+    id: "draft",
+    eventId,
+  };
+
+  const [templates, setTemplates] = useState<BadgeTemplate[]>(initialTemplates);
+  const [selectedTemplateId, setSelectedTemplateId] = useState(initialTemplate.id);
+  const [draft, setDraft] = useState<BadgeTemplateInput>(templateToDraft(initialTemplate));
+  const [selectedElementId, setSelectedElementId] = useState(draft.elements[0]?.id || "");
+  const [attendees, setAttendees] = useState(initialAttendees);
+  const [selectedAttendeeIds, setSelectedAttendeeIds] = useState<string[]>(initialAttendees.map(attendee => attendee.registrationId));
+  const [sampleAttendeeId, setSampleAttendeeId] = useState(initialAttendees[0]?.registrationId || "");
+  const [statusFilter, setStatusFilter] = useState("CONFIRMED");
+  const [tierFilter, setTierFilter] = useState("");
+  const [searchFilter, setSearchFilter] = useState("");
+  const [pageMode, setPageMode] = useState<"sheet" | "single">("sheet");
+  const [saving, setSaving] = useState(false);
+  const [loadingAttendees, setLoadingAttendees] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [uploadingFallbackPhoto, setUploadingFallbackPhoto] = useState(false);
+  const [fallbackPhotoQueue, setFallbackPhotoQueue] = useState<PendingFallbackPhoto[]>([]);
+  const [fallbackPhotoQueueIndex, setFallbackPhotoQueueIndex] = useState(0);
+  const [exporting, setExporting] = useState(false);
+  const [notice, setNotice] = useState<{ severity: "success" | "info" | "warning" | "error"; message: string } | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const fallbackPhotoInputRef = useRef<HTMLInputElement | null>(null);
+  const activeFallbackPhoto = fallbackPhotoQueue[fallbackPhotoQueueIndex] || null;
+
+  const selectedTemplate = templates.find(template => template.id === selectedTemplateId) || null;
+  const selectedElement = draft.elements.find(element => element.id === selectedElementId) || null;
+  const sampleAttendee = attendees.find(attendee => attendee.registrationId === sampleAttendeeId) || attendees[0] || null;
+  const selectedAttendees = attendees.filter(attendee => selectedAttendeeIds.includes(attendee.registrationId));
+
+  const previewStyle = useMemo(
+    () => ({
+      width: "100%",
+      maxWidth: 560,
+      aspectRatio: `${draft.widthMm} / ${draft.heightMm}`,
+      backgroundColor: draft.background.color,
+      backgroundImage: draft.background.imageUrl ? `url("${draft.background.imageUrl}")` : undefined,
+      backgroundSize: draft.background.fit === "stretch" ? "100% 100%" : draft.background.fit,
+      backgroundPosition: `${draft.background.positionX}% ${draft.background.positionY}%`,
+      backgroundRepeat: "no-repeat",
+    }),
+    [draft],
+  );
+
+  const setDraftField = <K extends keyof BadgeTemplateInput>(field: K, value: BadgeTemplateInput[K]) => {
+    setDraft(current => ({ ...current, [field]: value }));
+  };
+
+  const updateElement = (elementId: string, patch: Partial<BadgeElement>) => {
+    setDraft(current => ({
+      ...current,
+      elements: current.elements.map(element => (element.id === elementId ? { ...element, ...patch } : element)),
+    }));
+  };
+
+  const selectTemplate = (templateId: string) => {
+    const template = templates.find(entry => entry.id === templateId);
+    if (!template) return;
+    setSelectedTemplateId(template.id);
+    setDraft(templateToDraft(template));
+    setSelectedElementId(template.elements[0]?.id || "");
+    setNotice(null);
+  };
+
+  const addTemplate = () => {
+    const template: BadgeTemplate = {
+      ...fallbackTemplate,
+      id: "draft",
+      eventId,
+      name: `${eventName} Badge`,
+      isDefault: templates.length === 0,
+    };
+    setSelectedTemplateId(template.id);
+    setDraft(templateToDraft(template));
+    setSelectedElementId(template.elements[0]?.id || "");
+  };
+
+  const duplicateTemplate = () => {
+    setSelectedTemplateId("draft");
+    setDraft(current => ({ ...current, name: `${current.name} Copy`, isDefault: false }));
+    setNotice({ severity: "info", message: "Duplicated as an unsaved template." });
+  };
+
+  const saveTemplate = async () => {
+    setSaving(true);
+    setNotice(null);
+    try {
+      const isExisting = selectedTemplateId !== "draft" && !!selectedTemplate;
+      const response = await fetch(
+        isExisting
+          ? `/api/admin/event/${eventId}/badge-templates/${selectedTemplateId}`
+          : `/api/admin/event/${eventId}/badge-templates`,
+        {
+          method: isExisting ? "PATCH" : "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(draft),
+        },
+      );
+      const payload = (await response.json().catch(() => null)) as { template?: BadgeTemplate; error?: unknown } | null;
+      if (!response.ok || !payload?.template) {
+        throw new Error(getErrorMessage(payload, "Failed to save badge template"));
+      }
+
+      setTemplates(current => {
+        const without = current.filter(template => template.id !== payload.template?.id);
+        const next = [payload.template as BadgeTemplate, ...without].map(template => ({
+          ...template,
+          isDefault: payload.template?.isDefault ? template.id === payload.template.id : template.isDefault,
+        }));
+        return next.sort((a, b) => Number(b.isDefault) - Number(a.isDefault));
+      });
+      setSelectedTemplateId(payload.template.id);
+      setDraft(templateToDraft(payload.template));
+      setNotice({ severity: "success", message: "Badge template saved." });
+    } catch (error) {
+      setNotice({ severity: "error", message: error instanceof Error ? error.message : "Failed to save badge template" });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const deleteTemplate = async () => {
+    if (selectedTemplateId === "draft" || !selectedTemplate) {
+      addTemplate();
+      return;
+    }
+
+    setSaving(true);
+    setNotice(null);
+    try {
+      const response = await fetch(`/api/admin/event/${eventId}/badge-templates/${selectedTemplateId}`, {
+        method: "DELETE",
+      });
+      if (!response.ok) {
+        const payload = await response.json().catch(() => null);
+        throw new Error(getErrorMessage(payload, "Failed to delete badge template"));
+      }
+
+      const nextTemplates = templates.filter(template => template.id !== selectedTemplateId);
+      setTemplates(nextTemplates);
+      const next = nextTemplates[0] || { ...fallbackTemplate, id: "draft", eventId };
+      setSelectedTemplateId(next.id);
+      setDraft(templateToDraft(next));
+      setSelectedElementId(next.elements[0]?.id || "");
+      setNotice({ severity: "success", message: "Badge template deleted." });
+    } catch (error) {
+      setNotice({ severity: "error", message: error instanceof Error ? error.message : "Failed to delete badge template" });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const fetchAttendees = async () => {
+    setLoadingAttendees(true);
+    setNotice(null);
+    try {
+      const params = new URLSearchParams({ status: statusFilter });
+      if (tierFilter) params.set("ticketTier", tierFilter);
+      if (searchFilter.trim()) params.set("search", searchFilter.trim());
+
+      const response = await fetch(`/api/admin/event/${eventId}/badges/attendees?${params.toString()}`);
+      const payload = (await response.json().catch(() => null)) as { attendees?: BadgeAttendee[]; error?: unknown } | null;
+      if (!response.ok || !payload?.attendees) {
+        throw new Error(getErrorMessage(payload, "Failed to load attendees"));
+      }
+
+      setAttendees(payload.attendees);
+      setSelectedAttendeeIds(payload.attendees.map(attendee => attendee.registrationId));
+      setSampleAttendeeId(payload.attendees[0]?.registrationId || "");
+    } catch (error) {
+      setNotice({ severity: "error", message: error instanceof Error ? error.message : "Failed to load attendees" });
+    } finally {
+      setLoadingAttendees(false);
+    }
+  };
+
+  const addElement = (type: BadgeFieldKey) => {
+    const element = createElement(type);
+    setDraft(current => ({ ...current, elements: [...current.elements, element] }));
+    setSelectedElementId(element.id);
+  };
+
+  const moveElement = (elementId: string, direction: -1 | 1) => {
+    setDraft(current => {
+      const index = current.elements.findIndex(element => element.id === elementId);
+      const nextIndex = index + direction;
+      if (index === -1 || nextIndex < 0 || nextIndex >= current.elements.length) return current;
+
+      const elements = [...current.elements];
+      const [element] = elements.splice(index, 1);
+      elements.splice(nextIndex, 0, element);
+      return { ...current, elements };
+    });
+  };
+
+  const removeElement = () => {
+    if (!selectedElement) return;
+    const remaining = draft.elements.filter(element => element.id !== selectedElement.id);
+    setDraft(current => ({ ...current, elements: remaining }));
+    setSelectedElementId(remaining[0]?.id || "");
+  };
+
+  const handleBackgroundUpload = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    setUploading(true);
+    setNotice(null);
+    try {
+      const formData = new FormData();
+      formData.append("file", file);
+      const response = await fetch("/api/admin/media/upload", {
+        method: "POST",
+        body: formData,
+      });
+      const payload = (await response.json().catch(() => null)) as { url?: string; error?: unknown } | null;
+      if (!response.ok || !payload?.url) {
+        throw new Error(getErrorMessage(payload, "Failed to upload background image"));
+      }
+
+      setDraft(current => ({
+        ...current,
+        background: {
+          ...current.background,
+          imageUrl: payload.url,
+          positionX: current.background.positionX ?? 50,
+          positionY: current.background.positionY ?? 50,
+        },
+      }));
+    } catch (error) {
+      setNotice({ severity: "error", message: error instanceof Error ? error.message : "Failed to upload background image" });
+    } finally {
+      setUploading(false);
+      event.target.value = "";
+    }
+  };
+
+  const handleFallbackPhotoSelect = async (event: ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(event.target.files || []);
+    if (files.length === 0) return;
+
+    setNotice(null);
+    try {
+      const images = await Promise.all(files.map(file => new Promise<PendingFallbackPhoto>((resolve, reject) => {
+        if (!file.type.startsWith("image/")) {
+          reject(new Error("Please select image files only."));
+          return;
+        }
+        const reader = new FileReader();
+        reader.addEventListener("load", () => resolve({ name: file.name, src: reader.result?.toString() || "" }));
+        reader.addEventListener("error", () => reject(new Error("Failed to read fallback photo.")));
+        reader.readAsDataURL(file);
+      })));
+      setFallbackPhotoQueue(images.filter(image => image.src));
+      setFallbackPhotoQueueIndex(0);
+    } catch (error) {
+      setNotice({ severity: "error", message: error instanceof Error ? error.message : "Failed to prepare fallback photos" });
+    } finally {
+      event.target.value = "";
+    }
+  };
+
+  const closeFallbackPhotoCropper = () => {
+    setFallbackPhotoQueue([]);
+    setFallbackPhotoQueueIndex(0);
+    setUploadingFallbackPhoto(false);
+  };
+
+  const handleFallbackPhotoCropComplete = async (croppedBlob: Blob) => {
+    if (!activeFallbackPhoto) return;
+
+    setUploadingFallbackPhoto(true);
+    setNotice(null);
+    try {
+      const formData = new FormData();
+      const fileName = activeFallbackPhoto.name.replace(/\.[^.]+$/, "") || "fallback-photo";
+      formData.append("file", new File([croppedBlob], `${fileName}.jpg`, { type: "image/jpeg" }));
+      formData.append("mode", "badge-photo");
+      const response = await fetch("/api/admin/media/upload", {
+        method: "POST",
+        body: formData,
+      });
+      const payload = (await response.json().catch(() => null)) as { url?: string; error?: unknown } | null;
+      if (!response.ok || !payload?.url) {
+        throw new Error(getErrorMessage(payload, "Failed to upload fallback photo"));
+      }
+      const uploadedUrl = payload.url;
+
+      setDraft(current => ({
+        ...current,
+        background: {
+          ...current.background,
+          fallbackPhotoUrls: [...(current.background.fallbackPhotoUrls || []), uploadedUrl].slice(0, 30),
+        },
+      }));
+
+      if (fallbackPhotoQueueIndex + 1 >= fallbackPhotoQueue.length) {
+        closeFallbackPhotoCropper();
+      } else {
+        setFallbackPhotoQueueIndex(current => current + 1);
+      }
+    } catch (error) {
+      setNotice({ severity: "error", message: error instanceof Error ? error.message : "Failed to upload fallback photo" });
+    } finally {
+      setUploadingFallbackPhoto(false);
+    }
+  };
+
+  const removeFallbackPhoto = (url: string) => {
+    setDraft(current => ({
+      ...current,
+      background: {
+        ...current.background,
+        fallbackPhotoUrls: (current.background.fallbackPhotoUrls || []).filter(entry => entry !== url),
+      },
+    }));
+  };
+
+  const exportBadges = async (format: "html" | "png", printAfterOpen = false) => {
+    if (selectedAttendees.length === 0) {
+      setNotice({ severity: "warning", message: "Select at least one attendee." });
+      return;
+    }
+
+    setExporting(true);
+    setNotice(null);
+    try {
+      const attendeeIds = format === "png" ? [selectedAttendees[0].registrationId] : selectedAttendees.map(attendee => attendee.registrationId);
+      const response = await fetch(`/api/admin/event/${eventId}/badges/export`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          template: draft,
+          attendeeIds,
+          format,
+          pageMode,
+        }),
+      });
+
+      if (!response.ok) {
+        const payload = await response.json().catch(() => null);
+        throw new Error(getErrorMessage(payload, "Failed to export badges"));
+      }
+
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+
+      if (format === "html") {
+        const opened = window.open(url, "_blank");
+        if (printAfterOpen && opened) {
+          opened.addEventListener("load", () => opened.print(), { once: true });
+        }
+      } else {
+        const link = document.createElement("a");
+        link.href = url;
+        link.download = `badge-${selectedAttendees[0].ticketId}.png`;
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
+        window.setTimeout(() => URL.revokeObjectURL(url), 1000);
+      }
+    } catch (error) {
+      setNotice({ severity: "error", message: error instanceof Error ? error.message : "Failed to export badges" });
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const toggleAttendee = (registrationId: string, checked: boolean) => {
+    setSelectedAttendeeIds(current => checked ? [...new Set([...current, registrationId])] : current.filter(id => id !== registrationId));
+  };
+
+  return (
+    <>
+    <Stack spacing={3}>
+      <Stack direction={{ xs: "column", md: "row" }} justifyContent="space-between" spacing={2}>
+        <Box>
+          <Typography variant="h4" fontWeight={700}>Badge Designer</Typography>
+          <Typography variant="body2" color="text.secondary">{eventName}</Typography>
+        </Box>
+        <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+          <Button variant="outlined" startIcon={<Add />} onClick={addTemplate}>New</Button>
+          <Button variant="outlined" startIcon={<ContentCopy />} onClick={duplicateTemplate}>Duplicate</Button>
+          <Button variant="outlined" color="error" startIcon={<Delete />} onClick={() => void deleteTemplate()} disabled={saving}>Delete</Button>
+          <Button variant="contained" startIcon={saving ? <CircularProgress color="inherit" size={18} /> : <Save />} onClick={() => void saveTemplate()} disabled={saving}>Save</Button>
+        </Stack>
+      </Stack>
+
+      {notice ? <Alert severity={notice.severity}>{notice.message}</Alert> : null}
+
+      <Grid container spacing={2}>
+        <Grid size={{ xs: 12, lg: 3 }}>
+          <Paper variant="outlined" sx={{ p: 2 }}>
+            <Stack spacing={2}>
+              <Typography variant="h6">Template</Typography>
+              <TextField
+                select
+                label="Saved template"
+                value={selectedTemplateId}
+                onChange={event => selectTemplate(event.target.value)}
+                fullWidth
+              >
+                {selectedTemplateId === "draft" ? <MenuItem value="draft">Unsaved draft</MenuItem> : null}
+                {templates.map(template => (
+                  <MenuItem key={template.id} value={template.id}>{template.name}{template.isDefault ? " (default)" : ""}</MenuItem>
+                ))}
+              </TextField>
+              <TextField label="Name" value={draft.name} onChange={event => setDraftField("name", event.target.value)} fullWidth />
+              <FormControlLabel
+                control={<Checkbox checked={draft.isDefault} onChange={event => setDraftField("isDefault", event.target.checked)} />}
+                label="Default template"
+              />
+              <Stack direction="row" spacing={1}>
+                <TextField
+                  label="Width mm"
+                  type="number"
+                  value={draft.widthMm}
+                  onChange={event => setDraftField("widthMm", Number(event.target.value || 85))}
+                  fullWidth
+                />
+                <TextField
+                  label="Height mm"
+                  type="number"
+                  value={draft.heightMm}
+                  onChange={event => setDraftField("heightMm", Number(event.target.value || 55))}
+                  fullWidth
+                />
+              </Stack>
+              <TextField
+                label="Background color"
+                type="color"
+                value={draft.background.color}
+                onChange={event => setDraftField("background", { ...draft.background, color: event.target.value })}
+                fullWidth
+              />
+              <TextField
+                select
+                label="Background fit"
+                value={draft.background.fit}
+                onChange={event => setDraftField("background", { ...draft.background, fit: event.target.value as "cover" | "contain" | "stretch" })}
+                fullWidth
+              >
+                <MenuItem value="cover">Cover</MenuItem>
+                <MenuItem value="contain">Contain</MenuItem>
+                <MenuItem value="stretch">Stretch</MenuItem>
+              </TextField>
+              <input ref={fileInputRef} hidden type="file" accept="image/*" onChange={event => void handleBackgroundUpload(event)} />
+              <Button variant="outlined" startIcon={uploading ? <CircularProgress size={18} /> : <ImageIcon />} onClick={() => fileInputRef.current?.click()} disabled={uploading}>
+                Upload background
+              </Button>
+              {draft.background.imageUrl ? (
+                <>
+                  <Box>
+                    <Typography variant="caption" color="text.secondary">Background X</Typography>
+                    <Slider
+                      value={draft.background.positionX}
+                      onChange={(_, value) => setDraftField("background", { ...draft.background, positionX: value as number })}
+                      min={0}
+                      max={100}
+                      valueLabelDisplay="auto"
+                    />
+                  </Box>
+                  <Box>
+                    <Typography variant="caption" color="text.secondary">Background Y</Typography>
+                    <Slider
+                      value={draft.background.positionY}
+                      onChange={(_, value) => setDraftField("background", { ...draft.background, positionY: value as number })}
+                      min={0}
+                      max={100}
+                      valueLabelDisplay="auto"
+                    />
+                  </Box>
+                  <Button variant="text" color="error" onClick={() => setDraftField("background", { ...draft.background, imageUrl: null })}>
+                    Remove background
+                  </Button>
+                </>
+              ) : null}
+              <Divider />
+              <Stack spacing={1}>
+                <Typography variant="subtitle2">Fallback profile photos</Typography>
+                <Typography variant="caption" color="text.secondary">
+                  Used randomly for attendees with no profile picture.
+                </Typography>
+                <input ref={fallbackPhotoInputRef} hidden multiple type="file" accept="image/*" onChange={event => void handleFallbackPhotoSelect(event)} />
+                <Button
+                  variant="outlined"
+                  startIcon={uploadingFallbackPhoto ? <CircularProgress size={18} /> : <ImageIcon />}
+                  onClick={() => fallbackPhotoInputRef.current?.click()}
+                  disabled={uploadingFallbackPhoto || (draft.background.fallbackPhotoUrls || []).length >= 30}
+                >
+                  Upload fallback photos
+                </Button>
+                {(draft.background.fallbackPhotoUrls || []).length > 0 ? (
+                  <Grid container spacing={1}>
+                    {(draft.background.fallbackPhotoUrls || []).map(url => (
+                      <Grid key={url} size={{ xs: 4 }}>
+                        <Box
+                          sx={{
+                            position: "relative",
+                            aspectRatio: "1 / 1",
+                            overflow: "hidden",
+                            borderRadius: 1,
+                            border: "1px solid",
+                            borderColor: "divider",
+                          }}
+                        >
+                          <Image src={url} alt="" fill unoptimized style={{ objectFit: "cover" }} />
+                          <IconButton
+                            size="small"
+                            color="error"
+                            onClick={() => removeFallbackPhoto(url)}
+                            sx={{
+                              position: "absolute",
+                              top: 2,
+                              right: 2,
+                              bgcolor: "background.paper",
+                              "&:hover": { bgcolor: "background.paper" },
+                            }}
+                          >
+                            <Delete fontSize="inherit" />
+                          </IconButton>
+                        </Box>
+                      </Grid>
+                    ))}
+                  </Grid>
+                ) : null}
+              </Stack>
+            </Stack>
+          </Paper>
+        </Grid>
+
+        <Grid size={{ xs: 12, lg: 6 }}>
+          <Paper variant="outlined" sx={{ p: 2 }}>
+            <Stack spacing={2}>
+              <Stack direction="row" justifyContent="space-between" alignItems="center" gap={2}>
+                <Typography variant="h6">Preview</Typography>
+                <TextField
+                  select
+                  size="small"
+                  label="Sample attendee"
+                  value={sampleAttendeeId}
+                  onChange={event => setSampleAttendeeId(event.target.value)}
+                  sx={{ minWidth: 240 }}
+                >
+                  {attendees.map(attendee => (
+                    <MenuItem key={attendee.registrationId} value={attendee.registrationId}>
+                      #{attendee.ticketId} {attendee.displayName}
+                    </MenuItem>
+                  ))}
+                </TextField>
+              </Stack>
+
+              <Box sx={{ display: "flex", justifyContent: "center", overflowX: "auto", py: 2 }}>
+                <Box
+                  sx={{
+                    ...previewStyle,
+                    position: "relative",
+                    overflow: "hidden",
+                    border: "1px solid",
+                    borderColor: "divider",
+                    boxShadow: 2,
+                  }}
+                >
+                  {sampleAttendee ? draft.elements.map(element => {
+                    const photoUrl = element.type === "photo" ? getBadgePhotoUrl(draft, sampleAttendee) : null;
+                    const textValue = !isShapeElement(element) && element.type !== "photo" && element.type !== "qrCode"
+                      ? getBadgeElementValue(element, sampleAttendee, eventId)
+                      : "";
+                    const fittedText = textValue ? fitBadgeText(draft, element, textValue) : null;
+                    return (
+                      <Box
+                        key={element.id}
+                        onClick={() => setSelectedElementId(element.id)}
+                        sx={{
+                          position: "absolute",
+                          left: `${element.x}%`,
+                          top: `${element.y}%`,
+                          width: `${element.width}%`,
+                          height: `${element.height}%`,
+                          outline: selectedElementId === element.id ? "2px solid #2563eb" : "1px dashed rgba(15,23,42,0.25)",
+                          cursor: "pointer",
+                          overflow: "hidden",
+                          display: "flex",
+                          alignItems: "center",
+                          justifyContent: element.align === "center" ? "center" : element.align === "right" ? "flex-end" : "flex-start",
+                          textAlign: element.align,
+                          color: element.color,
+                          bgcolor: isShapeElement(element) ? element.backgroundColor || element.color : element.backgroundColor,
+                          borderRadius: isShapeElement(element) && (element.type === "ellipse" || element.type === "line") ? "999px" : undefined,
+                          border: element.borderWidth && element.borderWidth > 0 ? `${element.borderWidth}px solid ${element.borderColor || "#111827"}` : undefined,
+                          fontSize: fittedText?.fontSize ?? element.fontSize,
+                          fontWeight: element.fontWeight,
+                          lineHeight: 1.1,
+                          wordBreak: "break-word",
+                          overflowWrap: "anywhere",
+                          whiteSpace: "pre-wrap",
+                          boxSizing: "border-box",
+                          ...parseCustomCss(element.customCss),
+                        }}
+                      >
+                        {isShapeElement(element) ? null : element.type === "photo" ? (
+                          photoUrl ? (
+                            <Box sx={{ position: "relative", width: "100%", height: "100%", borderRadius: element.shape === "circle" ? "999px" : 1, overflow: "hidden" }}>
+                              <Image src={photoUrl} alt="" fill unoptimized style={{ objectFit: "cover" }} />
+                            </Box>
+                          ) : (
+                            <Box sx={{ width: "100%", height: "100%", bgcolor: "grey.200", display: "flex", alignItems: "center", justifyContent: "center", borderRadius: element.shape === "circle" ? "999px" : 1 }}>
+                              {attendeeInitials(sampleAttendee.displayName)}
+                            </Box>
+                          )
+                        ) : element.type === "qrCode" ? (
+                          <Box sx={{ width: "100%", height: "100%", bgcolor: "white", p: 0.5 }}>
+                            <QRCode value={getBadgeElementValue(element, sampleAttendee, eventId)} style={{ width: "100%", height: "100%" }} />
+                          </Box>
+                        ) : (
+                          textValue
+                        )}
+                      </Box>
+                    );
+                  }) : (
+                    <Box sx={{ height: "100%", display: "flex", alignItems: "center", justifyContent: "center" }}>
+                      <Typography color="text.secondary">No attendee selected</Typography>
+                    </Box>
+                  )}
+                </Box>
+              </Box>
+
+              <Divider />
+              <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                {FIELD_OPTIONS.map(option => (
+                  <Button key={option.value} size="small" variant="outlined" onClick={() => addElement(option.value)}>
+                    {option.label}
+                  </Button>
+                ))}
+              </Stack>
+              <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                {SHAPE_OPTIONS.map(option => {
+                  const Icon = option.icon;
+                  return (
+                    <Button key={option.value} size="small" variant="outlined" startIcon={<Icon />} onClick={() => addElement(option.value)}>
+                      {option.label}
+                    </Button>
+                  );
+                })}
+              </Stack>
+            </Stack>
+          </Paper>
+        </Grid>
+
+        <Grid size={{ xs: 12, lg: 3 }}>
+          <Paper variant="outlined" sx={{ p: 2 }}>
+            <Stack spacing={2}>
+              <Typography variant="h6">Layers</Typography>
+              {draft.elements.length === 0 ? (
+                <Alert severity="info">No elements yet.</Alert>
+              ) : (
+                <Stack spacing={1}>
+                  {[...draft.elements].reverse().map(element => {
+                    const index = draft.elements.findIndex(entry => entry.id === element.id);
+                    return (
+                      <Paper
+                        key={element.id}
+                        variant="outlined"
+                        onClick={() => setSelectedElementId(element.id)}
+                        sx={{
+                          p: 1,
+                          cursor: "pointer",
+                          borderColor: selectedElementId === element.id ? "primary.main" : "divider",
+                          bgcolor: selectedElementId === element.id ? "action.selected" : "background.paper",
+                        }}
+                      >
+                        <Stack direction="row" alignItems="center" spacing={1}>
+                          <Box sx={{ minWidth: 0, flex: 1 }}>
+                            <Typography variant="body2" fontWeight={600} noWrap>{element.label}</Typography>
+                            <Typography variant="caption" color="text.secondary">{TYPE_OPTIONS.find(option => option.value === element.type)?.label || element.type}</Typography>
+                          </Box>
+                          <Tooltip title="Move forward">
+                            <span>
+                              <IconButton size="small" onClick={event => { event.stopPropagation(); moveElement(element.id, 1); }} disabled={index === draft.elements.length - 1}>
+                                <KeyboardArrowUp fontSize="small" />
+                              </IconButton>
+                            </span>
+                          </Tooltip>
+                          <Tooltip title="Move back">
+                            <span>
+                              <IconButton size="small" onClick={event => { event.stopPropagation(); moveElement(element.id, -1); }} disabled={index === 0}>
+                                <KeyboardArrowDown fontSize="small" />
+                              </IconButton>
+                            </span>
+                          </Tooltip>
+                        </Stack>
+                      </Paper>
+                    );
+                  })}
+                </Stack>
+              )}
+              <Divider />
+              <Stack direction="row" justifyContent="space-between" alignItems="center">
+                <Typography variant="h6">Element</Typography>
+                <Tooltip title="Remove element">
+                  <span>
+                    <IconButton size="small" color="error" onClick={removeElement} disabled={!selectedElement}>
+                      <Delete fontSize="small" />
+                    </IconButton>
+                  </span>
+                </Tooltip>
+              </Stack>
+              {!selectedElement ? <Alert severity="info">Select or add an element.</Alert> : (
+                <>
+                  <TextField label="Label" value={selectedElement.label} onChange={event => updateElement(selectedElement.id, { label: event.target.value })} fullWidth />
+                  <TextField
+                    select
+                    label="Type"
+                    value={selectedElement.type}
+                    onChange={event => updateElement(selectedElement.id, { type: event.target.value as BadgeFieldKey })}
+                    fullWidth
+                  >
+                    {TYPE_OPTIONS.map(option => <MenuItem key={option.value} value={option.value}>{option.label}</MenuItem>)}
+                  </TextField>
+                  {selectedElement.type === "customField" ? (
+                    <TextField
+                      select
+                      label="Custom field"
+                      value={selectedElement.customFieldId || ""}
+                      onChange={event => updateElement(selectedElement.id, { customFieldId: event.target.value })}
+                      fullWidth
+                    >
+                      {customFields.map(field => <MenuItem key={field.id} value={field.id}>{field.label}</MenuItem>)}
+                    </TextField>
+                  ) : null}
+                  {selectedElement.type === "staticText" ? (
+                    <TextField label="Text" value={selectedElement.staticText || ""} onChange={event => updateElement(selectedElement.id, { staticText: event.target.value })} fullWidth multiline minRows={2} />
+                  ) : null}
+                  {(["x", "y", "width", "height"] as const).map(field => (
+                    <Box key={field}>
+                      <Typography variant="caption" color="text.secondary">{field.toUpperCase()}</Typography>
+                      <Slider value={selectedElement[field]} onChange={(_, value) => updateElement(selectedElement.id, { [field]: value as number })} min={field === "width" || field === "height" ? 1 : 0} max={100} />
+                    </Box>
+                  ))}
+                  {isShapeElement(selectedElement) ? (
+                    <>
+                      <TextField
+                        label={selectedElement.type === "line" ? "Line color" : "Fill"}
+                        type="color"
+                        value={colorInputValue(selectedElement.backgroundColor || selectedElement.color, "#2563eb")}
+                        onChange={event => updateElement(selectedElement.id, { backgroundColor: event.target.value, color: event.target.value })}
+                        fullWidth
+                      />
+                      <TextField
+                        label="Stroke"
+                        type="color"
+                        value={colorInputValue(selectedElement.borderColor, "#111827")}
+                        onChange={event => updateElement(selectedElement.id, { borderColor: event.target.value })}
+                        fullWidth
+                      />
+                      <Box>
+                        <Typography variant="caption" color="text.secondary">Stroke width</Typography>
+                        <Slider
+                          value={selectedElement.borderWidth || 0}
+                          onChange={(_, value) => updateElement(selectedElement.id, { borderWidth: value as number })}
+                          min={0}
+                          max={20}
+                          valueLabelDisplay="auto"
+                        />
+                      </Box>
+                    </>
+                  ) : (
+                    <>
+                      <TextField label="Font size" type="number" value={selectedElement.fontSize} onChange={event => updateElement(selectedElement.id, { fontSize: Number(event.target.value || 12) })} fullWidth />
+                      <TextField label="Color" type="color" value={colorInputValue(selectedElement.color, "#111827")} onChange={event => updateElement(selectedElement.id, { color: event.target.value })} fullWidth />
+                      <Stack direction="row" spacing={1}>
+                        <TextField
+                          select
+                          label="Weight"
+                          value={selectedElement.fontWeight}
+                          onChange={event => updateElement(selectedElement.id, { fontWeight: event.target.value as "400" | "600" | "700" })}
+                          fullWidth
+                        >
+                          <MenuItem value="400">Regular</MenuItem>
+                          <MenuItem value="600">Semi</MenuItem>
+                          <MenuItem value="700">Bold</MenuItem>
+                        </TextField>
+                        <TextField
+                          select
+                          label="Align"
+                          value={selectedElement.align}
+                          onChange={event => updateElement(selectedElement.id, { align: event.target.value as "left" | "center" | "right" })}
+                          fullWidth
+                        >
+                          <MenuItem value="left">Left</MenuItem>
+                          <MenuItem value="center">Center</MenuItem>
+                          <MenuItem value="right">Right</MenuItem>
+                        </TextField>
+                      </Stack>
+                    </>
+                  )}
+                  {selectedElement.type === "photo" ? (
+                    <TextField
+                      select
+                      label="Shape"
+                      value={selectedElement.shape}
+                      onChange={event => updateElement(selectedElement.id, { shape: event.target.value as "square" | "circle" })}
+                      fullWidth
+                    >
+                      <MenuItem value="square">Square</MenuItem>
+                      <MenuItem value="circle">Circle</MenuItem>
+                    </TextField>
+                  ) : null}
+                  <TextField
+                    label="Custom CSS"
+                    value={selectedElement.customCss || ""}
+                    onChange={event => updateElement(selectedElement.id, { customCss: event.target.value })}
+                    fullWidth
+                    multiline
+                    minRows={3}
+                    placeholder="transform: rotate(-2deg);"
+                  />
+                </>
+              )}
+            </Stack>
+          </Paper>
+        </Grid>
+      </Grid>
+
+      <Paper variant="outlined" sx={{ p: 2 }}>
+        <Stack spacing={2}>
+          <Stack direction={{ xs: "column", md: "row" }} justifyContent="space-between" spacing={2}>
+            <Typography variant="h6">Attendees</Typography>
+            <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+              <TextField select size="small" label="Status" value={statusFilter} onChange={event => setStatusFilter(event.target.value)} sx={{ minWidth: 160 }}>
+                <MenuItem value="CONFIRMED">Confirmed</MenuItem>
+                <MenuItem value="APPROVED">Approved</MenuItem>
+                <MenuItem value="PENDING">Pending</MenuItem>
+                <MenuItem value="WAITLISTED">Waitlisted</MenuItem>
+                <MenuItem value="ALL">All active</MenuItem>
+              </TextField>
+              <TextField select size="small" label="Ticket tier" value={tierFilter} onChange={event => setTierFilter(event.target.value)} sx={{ minWidth: 180 }}>
+                <MenuItem value="">All tiers</MenuItem>
+                {ticketTiers.map(tier => <MenuItem key={tier.id} value={tier.id}>{tier.name}</MenuItem>)}
+              </TextField>
+              <TextField size="small" label="Search" value={searchFilter} onChange={event => setSearchFilter(event.target.value)} />
+              <Button variant="outlined" onClick={() => void fetchAttendees()} disabled={loadingAttendees}>
+                {loadingAttendees ? <CircularProgress size={18} /> : "Apply"}
+              </Button>
+            </Stack>
+          </Stack>
+
+          <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap>
+            <Chip label={`${selectedAttendees.length} selected`} />
+            <Button size="small" onClick={() => setSelectedAttendeeIds(attendees.map(attendee => attendee.registrationId))}>Select all</Button>
+            <Button size="small" onClick={() => setSelectedAttendeeIds([])}>Clear</Button>
+            <TextField
+              select
+              size="small"
+              label="Print layout"
+              value={pageMode}
+              onChange={event => setPageMode(event.target.value as "sheet" | "single")}
+              sx={{ minWidth: 170 }}
+            >
+              <MenuItem value="sheet">Sheet</MenuItem>
+              <MenuItem value="single">One per page</MenuItem>
+            </TextField>
+            <Button startIcon={<Print />} variant="contained" onClick={() => void exportBadges("html", true)} disabled={exporting}>Print</Button>
+            <Button startIcon={<Download />} variant="outlined" onClick={() => void exportBadges("html")} disabled={exporting}>Open PDF view</Button>
+            <Button startIcon={<Download />} variant="outlined" onClick={() => void exportBadges("png")} disabled={exporting || selectedAttendees.length === 0}>PNG first selected</Button>
+          </Stack>
+
+          <Grid container spacing={1}>
+            {attendees.map(attendee => (
+              <Grid key={attendee.registrationId} size={{ xs: 12, sm: 6, md: 4, lg: 3 }}>
+                <Paper variant="outlined" sx={{ p: 1.5 }}>
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        checked={selectedAttendeeIds.includes(attendee.registrationId)}
+                        onChange={event => toggleAttendee(attendee.registrationId, event.target.checked)}
+                      />
+                    }
+                    label={
+                      <Box>
+                        <Typography variant="body2" fontWeight={600}>#{attendee.ticketId} {attendee.displayName}</Typography>
+                        <Typography variant="caption" color="text.secondary">{attendee.ticketTier || "Ticket"} • {attendee.email}</Typography>
+                      </Box>
+                    }
+                    sx={{ alignItems: "flex-start", m: 0 }}
+                  />
+                </Paper>
+              </Grid>
+            ))}
+          </Grid>
+          {attendees.length === 0 ? <Alert severity="info">No attendees match the current filters.</Alert> : null}
+        </Stack>
+      </Paper>
+    </Stack>
+    <ImageCropper
+      open={!!activeFallbackPhoto}
+      imageSrc={activeFallbackPhoto?.src || null}
+      onCancel={closeFallbackPhotoCropper}
+      onCropComplete={handleFallbackPhotoCropComplete}
+      aspect={1}
+    />
+    </>
+  );
+}

--- a/src/components/admin/events/EventList.tsx
+++ b/src/components/admin/events/EventList.tsx
@@ -24,7 +24,8 @@ import {
   Delete, 
   Add, 
   Visibility,
-  QrCodeScanner
+  QrCodeScanner,
+  Badge
 } from '@mui/icons-material';
 import Link from 'next/link';
 import type { SerializedEvent } from '@/types/event';
@@ -94,7 +95,7 @@ export default function EventList({ initialEvents }: EventListProps) {
     {
       field: 'actions',
       headerName: 'Actions',
-      width: 190,
+      width: 230,
       sortable: false,
       renderCell: (params: GridRenderCellParams) => (
         <Stack direction="row" spacing={1}>
@@ -120,6 +121,14 @@ export default function EventList({ initialEvents }: EventListProps) {
             title="Check-in"
           >
             <QrCodeScanner fontSize="small" />
+          </IconButton>
+          <IconButton
+            size="small"
+            component={Link}
+            href={`/admin/events/${params.row.id}/badges`}
+            title="Badges"
+          >
+            <Badge fontSize="small" />
           </IconButton>
           <IconButton 
             size="small" 

--- a/src/components/admin/events/ScheduleCalendarBuilder.tsx
+++ b/src/components/admin/events/ScheduleCalendarBuilder.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import React, { useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import FullCalendar from '@fullcalendar/react';
 import timeGridPlugin from '@fullcalendar/timegrid';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import interactionPlugin from '@fullcalendar/interaction';
+import type { DateSelectArg, EventApi, EventClickArg, EventDropArg } from '@fullcalendar/core';
+import type { EventResizeDoneArg } from '@fullcalendar/interaction';
 import { Box, Paper, Dialog, DialogTitle, DialogContent, DialogActions, Button, TextField, Grid } from '@mui/material';
 
 export interface ScheduleItem {
@@ -39,7 +41,7 @@ export default function ScheduleCalendarBuilder({ items, onChange, eventStartDat
     }
   }));
 
-  const handleDateSelect = (selectInfo: any) => {
+  const handleDateSelect = (selectInfo: DateSelectArg) => {
     setEditingItem({
       title: '',
       startTime: selectInfo.startStr,
@@ -51,7 +53,7 @@ export default function ScheduleCalendarBuilder({ items, onChange, eventStartDat
     selectInfo.view.calendar.unselect(); // clear date selection
   };
 
-  const handleEventClick = (clickInfo: any) => {
+  const handleEventClick = (clickInfo: EventClickArg) => {
     const props = clickInfo.event.extendedProps;
     setEditingItem({
       id: clickInfo.event.id,
@@ -64,15 +66,15 @@ export default function ScheduleCalendarBuilder({ items, onChange, eventStartDat
     setDialogOpen(true);
   };
 
-  const handleEventDrop = (dropInfo: any) => {
+  const handleEventDrop = (dropInfo: EventDropArg) => {
     updateEventFromCalendar(dropInfo.event);
   };
 
-  const handleEventResize = (resizeInfo: any) => {
+  const handleEventResize = (resizeInfo: EventResizeDoneArg) => {
     updateEventFromCalendar(resizeInfo.event);
   };
 
-  const updateEventFromCalendar = (eventInput: any) => {
+  const updateEventFromCalendar = (eventInput: EventApi) => {
     const updatedItems = items.map((item, index) => {
       const matchId = item.id || `item-${index}`;
       if (matchId === eventInput.id) {

--- a/src/components/admin/registrations/RegistrationManager.tsx
+++ b/src/components/admin/registrations/RegistrationManager.tsx
@@ -754,8 +754,8 @@ export default function RegistrationManager() {
                   )}
 
                   <Box sx={{ bgcolor: 'grey.50', p: 1, borderRadius: 1 }}>
-                    {item.changes.map((change, idx) => (
-                      <Grid container key={idx} spacing={1} sx={{ py: 0.5 }}>
+                    {item.changes.map((change) => (
+                      <Grid container key={`${change.label}:${change.old}:${change.new}`} spacing={1} sx={{ py: 0.5 }}>
                         <Grid size={{ xs: 4 }}>
                           <Typography variant="caption" fontWeight="bold">{change.label}:</Typography>
                         </Grid>
@@ -787,7 +787,7 @@ export default function RegistrationManager() {
         <DialogTitle>Payment Details: #{selectedReg?.payments[0]?.id.slice(-8)}</DialogTitle>
         <DialogContent dividers>
           {selectedReg?.payments[0] && (
-            <Stack spacing={3} id="invoice-content">
+            <Stack spacing={3}>
               <Box sx={{ textAlign: 'center', mb: 2 }}>
                 <Typography variant="h5" color="primary" fontWeight="bold">INVOICE</Typography>
                 <Typography variant="caption" color="text.secondary">Ventry Event Management</Typography>

--- a/src/components/emails/RegistrationUpdateMail.tsx
+++ b/src/components/emails/RegistrationUpdateMail.tsx
@@ -143,8 +143,8 @@ export default function RegistrationUpdateMail({
             {changes && changes.length > 0 && (
                 <div style={emailStyles.changeList}>
                     <p style={{ ...emailStyles.text, fontWeight: 'bold', marginBottom: '16px' }}>What changed:</p>
-                    {changes.map((change, i) => (
-                        <div key={i} style={emailStyles.changeItem}>
+                    {changes.map((change) => (
+                        <div key={`${change.label}:${change.old}:${change.new}`} style={emailStyles.changeItem}>
                             <div style={{ fontSize: '14px', color: '#666666', marginBottom: '4px' }}>{change.label}</div>
                             <div>
                                 <span style={emailStyles.oldValue}>{change.old}</span>

--- a/src/components/events/EventLocationMap.tsx
+++ b/src/components/events/EventLocationMap.tsx
@@ -15,7 +15,7 @@ import {
   Typography,
 } from "@mui/material";
 import { Close, OpenInFull } from "@mui/icons-material";
-import { type SerializedLocation } from "@/types/event";
+import type { SerializedLocation } from "@/types/event";
 
 interface EventLocationMapProps {
   location: SerializedLocation;

--- a/src/components/events/EventSchedule.tsx
+++ b/src/components/events/EventSchedule.tsx
@@ -85,9 +85,9 @@ export default function EventSchedule({ schedule }: EventScheduleProps) {
             </Box>
 
             <Stack spacing={2}>
-              {dayItems.map((item, index) => (
+              {dayItems.map((item) => (
                 <Paper 
-                  key={index} 
+                  key={item.id || `${dateKey}:${item.startTime}:${item.endTime || ""}:${item.title}`} 
                   variant="outlined" 
                   sx={{ 
                     p: 2,

--- a/src/lib/auth/event-admin.test.ts
+++ b/src/lib/auth/event-admin.test.ts
@@ -65,7 +65,7 @@ describe("checkEventAdminAuth", () => {
 
     await expect(checkEventAdminAuth(7)).resolves.toEqual({
       authorized: false,
-      error: "Only this event's admin can manage these support tickets",
+      error: "Only this event's admin can manage this event",
     });
   });
 

--- a/src/lib/auth/event-admin.ts
+++ b/src/lib/auth/event-admin.ts
@@ -17,7 +17,7 @@ type EventAdminAuthResult = {
 
 /**
  * Authorizes admin users for a specific event.
- * If an event has an owner, only that owner can manage event-specific support tickets.
+ * If an event has an owner, only that owner can manage event-specific admin data.
  */
 export async function checkEventAdminAuth(
   eventId: number,
@@ -46,7 +46,7 @@ export async function checkEventAdminAuth(
   }
 
   if (event.ownerId && event.ownerId !== adminAuth.adminId) {
-    return { authorized: false, error: "Only this event's admin can manage these support tickets" };
+    return { authorized: false, error: "Only this event's admin can manage this event" };
   }
 
   return {

--- a/src/lib/badges/badge.test.ts
+++ b/src/lib/badges/badge.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it, vi } from "vitest";
+import { DEFAULT_BADGE_TEMPLATE, attendeeInitials, fitBadgeText, getBadgeElementValue, getBadgePhotoUrl, type BadgeAttendee } from "./badge";
+import { badgeTemplateInputSchema } from "@/types/schemas/badge";
+
+vi.mock("@/lib/user/profilePicture", () => ({
+  refreshSignedUrls: vi.fn(async pictures => pictures),
+}));
+
+const attendee: BadgeAttendee = {
+  id: "reg-1",
+  registrationId: "reg-1",
+  ticketId: 42,
+  status: "CONFIRMED",
+  displayName: "Ada Lovelace",
+  legalName: "Augusta Ada King",
+  email: "ada@example.com",
+  photoUrl: "https://cdn.example.com/ada.jpg",
+  ticketTier: "Weekend Pass",
+  eventName: "Ventry Con",
+  customFieldData: {
+    handle: "ada",
+    helper: true,
+  },
+};
+
+describe("badge templates", () => {
+  it("validates the default badge template", () => {
+    expect(badgeTemplateInputSchema.safeParse(DEFAULT_BADGE_TEMPLATE).success).toBe(true);
+  });
+
+  it("validates shape elements with optional custom CSS", () => {
+    const result = badgeTemplateInputSchema.safeParse({
+      ...DEFAULT_BADGE_TEMPLATE,
+      elements: [
+        ...DEFAULT_BADGE_TEMPLATE.elements,
+        {
+          id: "accent",
+          type: "rectangle",
+          label: "Accent",
+          x: 5,
+          y: 80,
+          width: 90,
+          height: 4,
+          fontSize: 8,
+          fontWeight: "600",
+          color: "#2563eb",
+          align: "left",
+          shape: "square",
+          backgroundColor: "#2563eb",
+          borderColor: "#1d4ed8",
+          borderWidth: 1,
+          customCss: "opacity:0.7;",
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("resolves attendee-backed field values", () => {
+    expect(getBadgeElementValue({ ...DEFAULT_BADGE_TEMPLATE.elements[1], type: "displayName" }, attendee, 7)).toBe("Ada Lovelace");
+    expect(getBadgeElementValue({ ...DEFAULT_BADGE_TEMPLATE.elements[2], type: "ticketId" }, attendee, 7)).toBe("#42");
+    expect(getBadgeElementValue({ ...DEFAULT_BADGE_TEMPLATE.elements[3], type: "ticketTier" }, attendee, 7)).toBe("Weekend Pass");
+  });
+
+  it("resolves custom fields and QR payloads", () => {
+    expect(
+      getBadgeElementValue(
+        {
+          ...DEFAULT_BADGE_TEMPLATE.elements[1],
+          type: "customField",
+          customFieldId: "handle",
+        },
+        attendee,
+        7,
+      ),
+    ).toBe("ada");
+
+    expect(getBadgeElementValue({ ...DEFAULT_BADGE_TEMPLATE.elements[4], type: "qrCode" }, attendee, 7)).toBe("ventry:ticket:v1:7:42");
+  });
+
+  it("builds initials from display names", () => {
+    expect(attendeeInitials("Ada Lovelace")).toBe("AL");
+    expect(attendeeInitials("")).toBe("?");
+  });
+
+  it("assigns fallback photos only when attendees have no profile photo", () => {
+    const template = {
+      ...DEFAULT_BADGE_TEMPLATE,
+      background: {
+        ...DEFAULT_BADGE_TEMPLATE.background,
+        fallbackPhotoUrls: [
+          "https://cdn.example.com/fallback-1.jpg",
+          "https://cdn.example.com/fallback-2.jpg",
+        ],
+      },
+    };
+    const attendeeWithoutPhoto = { ...attendee, photoUrl: null };
+
+    expect(getBadgePhotoUrl(template, attendee)).toBe("https://cdn.example.com/ada.jpg");
+    expect(getBadgePhotoUrl(template, attendeeWithoutPhoto)).toMatch(/^https:\/\/cdn\.example\.com\/fallback-[12]\.jpg$/);
+    expect(getBadgePhotoUrl(template, attendeeWithoutPhoto)).toBe(getBadgePhotoUrl(template, attendeeWithoutPhoto));
+  });
+
+  it("reduces long text to fit inside its badge element", () => {
+    const element = {
+      ...DEFAULT_BADGE_TEMPLATE.elements[1],
+      width: 20,
+      height: 8,
+      fontSize: 18,
+    };
+    const fitted = fitBadgeText(DEFAULT_BADGE_TEMPLATE, element, "Ada Lovelace-Who-Has-A-Very-Long-Badge-Name");
+
+    expect(fitted.fontSize).toBeLessThan(18);
+    expect(fitted.lines.length).toBeGreaterThan(1);
+  });
+
+  it("renders printable QR fields as SVG instead of raw payload text", async () => {
+    process.env.DATABASE_URL ||= "prisma://localhost/?api_key=test";
+    const { renderPrintableBadgesHtml } = await import("./server");
+    const html = renderPrintableBadgesHtml(DEFAULT_BADGE_TEMPLATE, [attendee], 7, "sheet");
+
+    expect(html).toContain("<svg");
+    expect(html).not.toContain(">ventry:ticket:v1:7:42<");
+  });
+
+  it("renders printable backgrounds as positioned images", async () => {
+    process.env.DATABASE_URL ||= "prisma://localhost/?api_key=test";
+    const { renderPrintableBadgesHtml } = await import("./server");
+    const html = renderPrintableBadgesHtml(
+      {
+        ...DEFAULT_BADGE_TEMPLATE,
+        background: {
+          color: "#ffffff",
+          imageUrl: "https://cdn.example.com/badge-bg.jpg",
+          fit: "cover",
+          positionX: 25,
+          positionY: 75,
+        },
+      },
+      [attendee],
+      7,
+      "sheet",
+    );
+
+    expect(html).toContain('class="badge-bg"');
+    expect(html).toContain("object-position:25% 75%");
+  });
+
+  it("renders fallback photos for attendees without profile photos", async () => {
+    process.env.DATABASE_URL ||= "prisma://localhost/?api_key=test";
+    const { renderPrintableBadgesHtml } = await import("./server");
+    const html = renderPrintableBadgesHtml(
+      {
+        ...DEFAULT_BADGE_TEMPLATE,
+        background: {
+          ...DEFAULT_BADGE_TEMPLATE.background,
+          fallbackPhotoUrls: ["https://cdn.example.com/fallback.jpg"],
+        },
+      },
+      [{ ...attendee, photoUrl: null }],
+      7,
+      "sheet",
+    );
+
+    expect(html).toContain('src="https://cdn.example.com/fallback.jpg"');
+    expect(html).not.toContain(">AL<");
+  });
+
+  it("renders printable long text with a fitted font size", async () => {
+    process.env.DATABASE_URL ||= "prisma://localhost/?api_key=test";
+    const { renderPrintableBadgesHtml } = await import("./server");
+    const html = renderPrintableBadgesHtml(
+      {
+        ...DEFAULT_BADGE_TEMPLATE,
+        elements: [
+          {
+            ...DEFAULT_BADGE_TEMPLATE.elements[1],
+            width: 20,
+            height: 8,
+            fontSize: 18,
+          },
+        ],
+      },
+      [{ ...attendee, displayName: "Ada Lovelace-Who-Has-A-Very-Long-Badge-Name" }],
+      7,
+      "sheet",
+    );
+
+    expect(html).toContain("font-size:6px");
+  });
+
+  it("renders printable shape elements with custom CSS", async () => {
+    process.env.DATABASE_URL ||= "prisma://localhost/?api_key=test";
+    const { renderPrintableBadgesHtml } = await import("./server");
+    const html = renderPrintableBadgesHtml(
+      {
+        ...DEFAULT_BADGE_TEMPLATE,
+        elements: [
+          {
+            id: "line",
+            type: "line",
+            label: "Line",
+            x: 5,
+            y: 90,
+            width: 90,
+            height: 2,
+            fontSize: 8,
+            fontWeight: "600",
+            color: "#2563eb",
+            align: "left",
+            shape: "square",
+            backgroundColor: "#2563eb",
+            borderColor: "#1d4ed8",
+            borderWidth: 0,
+            customCss: "opacity:0.6;",
+          },
+        ],
+      },
+      [attendee],
+      7,
+      "sheet",
+    );
+
+    expect(html).toContain("border-radius:999px");
+    expect(html).toContain("opacity:0.6;");
+  });
+});

--- a/src/lib/badges/badge.ts
+++ b/src/lib/badges/badge.ts
@@ -1,0 +1,283 @@
+import { formatTicketQrPayload } from "@/lib/tickets/qr";
+import type { BadgeElement, BadgeTemplateInput } from "@/types/schemas/badge";
+
+export type BadgeAttendee = {
+  id: string;
+  registrationId: string;
+  ticketId: number;
+  status: "PENDING" | "APPROVED" | "CONFIRMED" | "CANCELLED" | "WAITLISTED";
+  displayName: string;
+  legalName: string | null;
+  email: string;
+  photoUrl: string | null;
+  ticketTier: string | null;
+  eventName: string;
+  customFieldData: Record<string, string | number | boolean | null>;
+};
+
+export type BadgeTemplate = BadgeTemplateInput & {
+  id: string;
+  eventId: number;
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+export const DEFAULT_BADGE_TEMPLATE: BadgeTemplateInput = {
+  name: "Default Badge",
+  isDefault: true,
+  widthMm: 85,
+  heightMm: 55,
+  background: {
+    color: "#f8fafc",
+    fit: "cover",
+    positionX: 50,
+    positionY: 50,
+    fallbackPhotoUrls: [],
+  },
+  elements: [
+    {
+      id: "photo",
+      type: "photo",
+      label: "Photo",
+      x: 6,
+      y: 12,
+      width: 28,
+      height: 43,
+      fontSize: 10,
+      fontWeight: "600",
+      color: "#111827",
+      align: "center",
+      shape: "square",
+    },
+    {
+      id: "name",
+      type: "displayName",
+      label: "Name",
+      x: 38,
+      y: 18,
+      width: 40,
+      height: 14,
+      fontSize: 17,
+      fontWeight: "700",
+      color: "#111827",
+      align: "left",
+      shape: "square",
+    },
+    {
+      id: "ticket",
+      type: "ticketId",
+      label: "Ticket Number",
+      x: 38,
+      y: 36,
+      width: 28,
+      height: 8,
+      fontSize: 9,
+      fontWeight: "600",
+      color: "#475569",
+      align: "left",
+      shape: "square",
+    },
+    {
+      id: "tier",
+      type: "ticketTier",
+      label: "Ticket Tier",
+      x: 38,
+      y: 47,
+      width: 32,
+      height: 8,
+      fontSize: 8,
+      fontWeight: "600",
+      color: "#334155",
+      align: "left",
+      shape: "square",
+    },
+    {
+      id: "qr",
+      type: "qrCode",
+      label: "QR Code",
+      x: 77,
+      y: 61,
+      width: 17,
+      height: 27,
+      fontSize: 8,
+      fontWeight: "600",
+      color: "#111827",
+      align: "center",
+      shape: "square",
+    },
+    {
+      id: "event",
+      type: "eventName",
+      label: "Event",
+      x: 6,
+      y: 4,
+      width: 88,
+      height: 8,
+      fontSize: 8,
+      fontWeight: "700",
+      color: "#334155",
+      align: "center",
+      shape: "square",
+    },
+  ],
+};
+
+export function getBadgeElementValue(element: BadgeElement, attendee: BadgeAttendee, eventId: number) {
+  switch (element.type) {
+    case "displayName":
+      return attendee.displayName;
+    case "legalName":
+      return attendee.legalName || attendee.displayName;
+    case "ticketId":
+      return `#${attendee.ticketId}`;
+    case "ticketTier":
+      return attendee.ticketTier || "Ticket";
+    case "eventName":
+      return attendee.eventName;
+    case "customField": {
+      const raw = element.customFieldId ? attendee.customFieldData[element.customFieldId] : null;
+      return raw === null || raw === undefined ? "" : String(raw);
+    }
+    case "staticText":
+      return element.staticText || "";
+    case "qrCode":
+      return formatTicketQrPayload({ eventId, ticketId: attendee.ticketId });
+    case "photo":
+      return attendee.photoUrl || "";
+    case "rectangle":
+    case "ellipse":
+    case "line":
+      return "";
+    default:
+      return "";
+  }
+}
+
+export function attendeeInitials(name: string) {
+  return name
+    .split(" ")
+    .filter(Boolean)
+    .map(part => part[0])
+    .slice(0, 2)
+    .join("")
+    .toUpperCase() || "?";
+}
+
+function stableIndex(value: string, length: number) {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 31 + value.charCodeAt(index)) >>> 0;
+  }
+  return hash % length;
+}
+
+export function getBadgePhotoUrl(template: BadgeTemplateInput, attendee: BadgeAttendee) {
+  if (attendee.photoUrl) return attendee.photoUrl;
+
+  const fallbackPhotoUrls = template.background.fallbackPhotoUrls || [];
+  if (fallbackPhotoUrls.length === 0) return null;
+
+  const key = attendee.registrationId || String(attendee.ticketId);
+  return fallbackPhotoUrls[stableIndex(key, fallbackPhotoUrls.length)];
+}
+
+function wrapTextToLines(value: string, maxCharsPerLine: number) {
+  const sourceLines = value.split(/\r?\n/);
+  const lines: string[] = [];
+
+  for (const sourceLine of sourceLines) {
+    const words = sourceLine.trim().split(/\s+/).filter(Boolean);
+    if (words.length === 0) {
+      lines.push("");
+      continue;
+    }
+
+    let current = "";
+    for (const word of words) {
+      if (word.length > maxCharsPerLine) {
+        if (current) {
+          lines.push(current);
+          current = "";
+        }
+        for (let index = 0; index < word.length; index += maxCharsPerLine) {
+          lines.push(word.slice(index, index + maxCharsPerLine));
+        }
+        continue;
+      }
+
+      const candidate = current ? `${current} ${word}` : word;
+      if (candidate.length > maxCharsPerLine && current) {
+        lines.push(current);
+        current = word;
+      } else {
+        current = candidate;
+      }
+    }
+
+    if (current) lines.push(current);
+  }
+
+  return lines.length === 0 ? [""] : lines;
+}
+
+export function fitBadgeText(template: BadgeTemplateInput, element: BadgeElement, value: string) {
+  const minFontSize = 6;
+  const maxFontSize = element.fontSize;
+  const widthPx = Math.max(1, template.widthMm * 3.78 * (element.width / 100));
+  const heightPx = Math.max(1, template.heightMm * 3.78 * (element.height / 100));
+
+  for (let fontSize = maxFontSize; fontSize >= minFontSize; fontSize -= 1) {
+    const maxCharsPerLine = Math.max(1, Math.floor(widthPx / (fontSize * 0.55)));
+    const lines = wrapTextToLines(value, maxCharsPerLine);
+    const neededHeight = lines.length * fontSize * 1.12;
+    if (neededHeight <= heightPx * 0.96) {
+      return { fontSize, lines };
+    }
+  }
+
+  return {
+    fontSize: minFontSize,
+    lines: wrapTextToLines(value, Math.max(1, Math.floor(widthPx / (minFontSize * 0.55)))),
+  };
+}
+
+export function normalizeBadgeTemplate(raw: {
+  id: string;
+  eventId: number;
+  name: string;
+  isDefault: boolean;
+  widthMm: number;
+  heightMm: number;
+  background: unknown;
+  elements: unknown;
+  createdAt?: Date | string;
+  updatedAt?: Date | string;
+}): BadgeTemplate {
+  const rawBackground = raw.background && typeof raw.background === "object" ? raw.background as Partial<BadgeTemplateInput["background"]> : {};
+
+  return {
+    id: raw.id,
+    eventId: raw.eventId,
+    name: raw.name,
+    isDefault: raw.isDefault,
+    widthMm: raw.widthMm,
+    heightMm: raw.heightMm,
+    background: {
+      color: rawBackground.color || DEFAULT_BADGE_TEMPLATE.background.color,
+      imageUrl: rawBackground.imageUrl || null,
+      fit: rawBackground.fit === "contain" || rawBackground.fit === "stretch" || rawBackground.fit === "cover"
+        ? rawBackground.fit
+        : DEFAULT_BADGE_TEMPLATE.background.fit,
+      positionX: typeof rawBackground.positionX === "number" ? rawBackground.positionX : 50,
+      positionY: typeof rawBackground.positionY === "number" ? rawBackground.positionY : 50,
+      fallbackPhotoUrls: Array.isArray(rawBackground.fallbackPhotoUrls)
+        ? rawBackground.fallbackPhotoUrls.filter((url): url is string => typeof url === "string")
+        : [],
+    },
+    elements: Array.isArray(raw.elements)
+      ? (raw.elements as BadgeTemplateInput["elements"])
+      : DEFAULT_BADGE_TEMPLATE.elements,
+    createdAt: raw.createdAt ? new Date(raw.createdAt).toISOString() : undefined,
+    updatedAt: raw.updatedAt ? new Date(raw.updatedAt).toISOString() : undefined,
+  };
+}

--- a/src/lib/badges/server.ts
+++ b/src/lib/badges/server.ts
@@ -1,0 +1,364 @@
+import ErrorCorrectLevel from "qr.js/lib/ErrorCorrectLevel";
+import QRCodeGenerator from "qr.js/lib/QRCode";
+import sharp from "sharp";
+import type { Prisma } from "@/generated/prisma";
+import { prisma } from "@/lib/prisma/prisma";
+import { attendeeInitials, fitBadgeText, getBadgeElementValue, getBadgePhotoUrl, type BadgeAttendee } from "@/lib/badges/badge";
+import { refreshSignedUrls } from "@/lib/user/profilePicture";
+import type { BadgeAttendeeQuery, BadgeElement, BadgeTemplateInput } from "@/types/schemas/badge";
+
+const PRINT_SCALE = 4;
+const SHAPE_ELEMENT_TYPES = new Set(["rectangle", "ellipse", "line"]);
+
+function escapeHtml(value: string) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
+}
+
+function escapeAttr(value: string) {
+  return escapeHtml(value);
+}
+
+function bytesToBinaryString(bytes: number[]) {
+  return bytes.map(byte => String.fromCharCode(byte & 0xff)).join("");
+}
+
+function encodeStringToUtf8Bytes(input: string) {
+  return Array.from(new TextEncoder().encode(input));
+}
+
+function getQrCells(value: string): boolean[][] {
+  const qrcode = new QRCodeGenerator(-1, ErrorCorrectLevel.M);
+  qrcode.addData(bytesToBinaryString(encodeStringToUtf8Bytes(value)), "Byte");
+  qrcode.make();
+  return qrcode.modules;
+}
+
+function renderQrSvg(value: string, attributes = "") {
+  const cells = getQrCells(value);
+  const fgD = cells
+    .map((row, rowIndex) =>
+      row.map((cell, cellIndex) => (cell ? `M ${cellIndex} ${rowIndex} l 1 0 0 1 -1 0 Z` : "")).join(" "),
+    )
+    .join(" ");
+
+  return `<svg ${attributes} viewBox="0 0 ${cells.length} ${cells.length}" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="#ffffff"/><path d="${fgD}" fill="#000000"/></svg>`;
+}
+
+function renderNestedQrSvg(value: string, element: BadgeElement) {
+  return renderQrSvg(
+    value,
+    `x="${element.x}%" y="${element.y}%" width="${element.width}%" height="${element.height}%" preserveAspectRatio="xMidYMid meet"`,
+  );
+}
+
+function toRecord(value: Prisma.JsonValue): Record<string, string | number | boolean | null> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).filter((entry): entry is [string, string | number | boolean | null] => {
+      const val = entry[1];
+      return val === null || typeof val === "string" || typeof val === "number" || typeof val === "boolean";
+    }),
+  );
+}
+
+export async function loadBadgeAttendees(eventId: number, query: BadgeAttendeeQuery): Promise<BadgeAttendee[]> {
+  const search = query.search?.trim();
+  const registrations = await prisma.registration.findMany({
+    where: {
+      eventId,
+      status:
+        query.status === "ALL"
+          ? { not: "CANCELLED" }
+          : query.status,
+      ...(search
+        ? {
+            user: {
+              OR: [
+                { name: { contains: search, mode: "insensitive" } },
+                { legalName: { contains: search, mode: "insensitive" } },
+                { email: { contains: search, mode: "insensitive" } },
+              ],
+            },
+          }
+        : {}),
+      ...(query.ticketTier
+        ? {
+            registrationItems: {
+              some: {
+                product: {
+                  id: query.ticketTier,
+                  type: "TICKET",
+                },
+              },
+            },
+          }
+        : {}),
+    },
+    include: {
+      event: {
+        select: {
+          name: true,
+        },
+      },
+      user: {
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          legalName: true,
+          image: true,
+          profilePictures: {
+            orderBy: [
+              { isPrimary: "desc" },
+              { order: "asc" },
+              { createdAt: "desc" },
+            ],
+            select: {
+              id: true,
+              signedUrl: true,
+              storagePath: true,
+              cachedUntil: true,
+              isPrimary: true,
+            },
+          },
+        },
+      },
+      registrationItems: {
+        include: {
+          product: {
+            select: {
+              id: true,
+              name: true,
+              type: true,
+            },
+          },
+        },
+      },
+    },
+    orderBy: [{ ticketId: "asc" }],
+  });
+
+  return Promise.all(registrations.map(async registration => {
+    const ticketItem = registration.registrationItems.find(item => item.product.type === "TICKET");
+    const profilePictures = await refreshSignedUrls(registration.user.profilePictures);
+    const primaryPicture = profilePictures.find(picture => picture.isPrimary) || profilePictures[0];
+
+    return {
+      id: registration.id,
+      registrationId: registration.id,
+      ticketId: registration.ticketId,
+      status: registration.status,
+      displayName: registration.user.name || registration.user.legalName || registration.user.email,
+      legalName: registration.user.legalName,
+      email: registration.user.email,
+      photoUrl: primaryPicture?.signedUrl || registration.user.image || null,
+      ticketTier: ticketItem?.product.name || null,
+      eventName: registration.event.name,
+      customFieldData: toRecord(registration.customFieldData as Prisma.JsonValue),
+    };
+  }));
+}
+
+export async function loadBadgeAttendeesByIds(eventId: number, registrationIds: string[]) {
+  const attendees = await loadBadgeAttendees(eventId, { status: "ALL" });
+  const idSet = new Set(registrationIds);
+  return attendees.filter(attendee => idSet.has(attendee.registrationId));
+}
+
+function backgroundCss(template: BadgeTemplateInput) {
+  return `background-color:${template.background.color || "#ffffff"};`;
+}
+
+function backgroundImageCss(template: BadgeTemplateInput) {
+  return [
+    "position:absolute",
+    "inset:0",
+    "width:100%",
+    "height:100%",
+    `object-fit:${template.background.fit === "stretch" ? "fill" : template.background.fit}`,
+    `object-position:${template.background.positionX}% ${template.background.positionY}%`,
+    "z-index:0",
+    "pointer-events:none",
+  ].join(";");
+}
+
+function isShapeElement(element: BadgeElement) {
+  return SHAPE_ELEMENT_TYPES.has(element.type);
+}
+
+function elementChromeCss(element: BadgeElement) {
+  const styles: string[] = [];
+  if (element.backgroundColor) {
+    styles.push(`background-color:${element.backgroundColor}`);
+  }
+  if (element.borderWidth !== undefined && element.borderWidth > 0) {
+    styles.push(`border:${element.borderWidth}px solid ${element.borderColor || "#111827"}`);
+  }
+  return styles;
+}
+
+function customCss(element: BadgeElement) {
+  return element.customCss?.trim() || "";
+}
+
+function elementCss(element: BadgeElement, extraStyles: string[] = []) {
+  return [
+    "position:absolute",
+    `left:${element.x}%`,
+    `top:${element.y}%`,
+    `width:${element.width}%`,
+    `height:${element.height}%`,
+    "z-index:1",
+    ...elementChromeCss(element),
+    `font-size:${element.fontSize}px`,
+    `font-weight:${element.fontWeight}`,
+    `color:${element.color}`,
+    `text-align:${element.align}`,
+    "overflow:hidden",
+    "display:flex",
+    "align-items:center",
+    element.align === "center" ? "justify-content:center" : element.align === "right" ? "justify-content:flex-end" : "justify-content:flex-start",
+    "line-height:1.1",
+    "word-break:break-word",
+    "overflow-wrap:anywhere",
+    ...extraStyles,
+    customCss(element),
+  ].join(";");
+}
+
+function renderElementHtml(element: BadgeElement, template: BadgeTemplateInput, attendee: BadgeAttendee, eventId: number) {
+  if (isShapeElement(element)) {
+    const shapeStyles = [
+      `background-color:${element.backgroundColor || element.color}`,
+      element.type === "ellipse" || element.type === "line" ? "border-radius:999px" : "border-radius:4px",
+      element.type === "line" ? `height:${element.height}%` : "",
+    ].filter(Boolean);
+    return `<div style="${escapeAttr(elementCss(element, shapeStyles))}"></div>`;
+  }
+
+  if (element.type === "photo") {
+    const photoUrl = getBadgePhotoUrl(template, attendee);
+    if (photoUrl) {
+      return `<img alt="" src="${escapeAttr(photoUrl)}" style="${escapeAttr(elementCss(element, ["object-fit:cover", `border-radius:${element.shape === "circle" ? "999px" : "4px"}`]))}" />`;
+    }
+
+    return `<div style="${escapeAttr(elementCss(element, ["background:#e2e8f0", `border-radius:${element.shape === "circle" ? "999px" : "4px"}`]))}">${escapeHtml(attendeeInitials(attendee.displayName))}</div>`;
+  }
+
+  if (element.type === "qrCode") {
+    const value = getBadgeElementValue(element, attendee, eventId);
+    return `<div style="${escapeAttr(elementCss(element, ["background:#fff", "border:1px solid #cbd5e1", "padding:2px"]))}">${renderQrSvg(value)}</div>`;
+  }
+
+  const value = getBadgeElementValue(element, attendee, eventId);
+  const fitted = fitBadgeText(template, element, value);
+  const css = elementCss(element, [`font-size:${fitted.fontSize}px`]);
+  return `<div style="${escapeAttr(css)}">${escapeHtml(value)}</div>`;
+}
+
+export function renderBadgeHtml(template: BadgeTemplateInput, attendee: BadgeAttendee, eventId: number) {
+  const elements = template.elements.map(element => renderElementHtml(element, template, attendee, eventId)).join("");
+  const backgroundImage = template.background.imageUrl
+    ? `<img alt="" class="badge-bg" src="${escapeAttr(template.background.imageUrl)}" style="${backgroundImageCss(template)}" />`
+    : "";
+
+  return `<section class="badge" style="width:${template.widthMm}mm;height:${template.heightMm}mm;${backgroundCss(template)}">${backgroundImage}${elements}</section>`;
+}
+
+export function renderPrintableBadgesHtml(
+  template: BadgeTemplateInput,
+  attendees: BadgeAttendee[],
+  eventId: number,
+  pageMode: "sheet" | "single",
+) {
+  const badges = attendees.map(attendee => renderBadgeHtml(template, attendee, eventId)).join("");
+  const pageBreak = pageMode === "single" ? ".badge{break-after:page;page-break-after:always;}" : "";
+
+  return `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>${escapeHtml(template.name)} Badges</title>
+<style>
+*{box-sizing:border-box}
+body{margin:0;padding:10mm;background:#f1f5f9;font-family:Arial,Helvetica,sans-serif}
+.sheet{display:flex;flex-wrap:wrap;gap:6mm;align-items:flex-start}
+.badge{position:relative;overflow:hidden;background:#fff;box-shadow:0 0 0 1px #cbd5e1;print-color-adjust:exact;-webkit-print-color-adjust:exact}
+.badge-bg{display:block;print-color-adjust:exact;-webkit-print-color-adjust:exact}
+.badge svg{width:100%;height:100%;display:block}
+${pageBreak}
+@page{size:auto;margin:8mm}
+@media print{
+  body{padding:0;background:#fff}
+  .sheet{gap:3mm}
+  .badge{box-shadow:none;border:0.2mm solid #cbd5e1}
+}
+</style>
+</head>
+<body>
+<main class="sheet">${badges}</main>
+</body>
+</html>`;
+}
+
+function svgText(template: BadgeTemplateInput, element: BadgeElement, value: string) {
+  const fitted = fitBadgeText(template, element, value);
+  const anchor = element.align === "center" ? "middle" : element.align === "right" ? "end" : "start";
+  const x = element.align === "center" ? element.x + element.width / 2 : element.align === "right" ? element.x + element.width : element.x;
+  const style = element.customCss ? ` style="${escapeAttr(element.customCss)}"` : "";
+  const lineHeight = fitted.fontSize * 1.12 * PRINT_SCALE;
+  const y = element.y + element.height / 2;
+  const startDy = -((fitted.lines.length - 1) * lineHeight) / 2;
+  const tspans = fitted.lines.map((line, index) => {
+    const dy = index === 0 ? startDy : lineHeight;
+    return `<tspan x="${x}%" dy="${dy}">${escapeHtml(line)}</tspan>`;
+  }).join("");
+  return `<text text-anchor="${anchor}" dominant-baseline="middle" font-size="${fitted.fontSize * PRINT_SCALE}" font-weight="${element.fontWeight}" fill="${escapeAttr(element.color)}" y="${y}%"${style}>${tspans}</text>`;
+}
+
+function svgShape(element: BadgeElement) {
+  const fill = escapeAttr(element.backgroundColor || element.color);
+  const stroke = element.borderWidth && element.borderWidth > 0
+    ? ` stroke="${escapeAttr(element.borderColor || "#111827")}" stroke-width="${element.borderWidth / PRINT_SCALE}"`
+    : "";
+  const style = element.customCss ? ` style="${escapeAttr(element.customCss)}"` : "";
+
+  if (element.type === "ellipse") {
+    return `<ellipse cx="${element.x + element.width / 2}%" cy="${element.y + element.height / 2}%" rx="${element.width / 2}%" ry="${element.height / 2}%" fill="${fill}"${stroke}${style}/>`;
+  }
+
+  return `<rect x="${element.x}%" y="${element.y}%" width="${element.width}%" height="${element.height}%" rx="${element.type === "line" ? "999" : "1"}" fill="${fill}"${stroke}${style}/>`;
+}
+
+export async function renderBadgePng(template: BadgeTemplateInput, attendee: BadgeAttendee, eventId: number) {
+  const width = Math.round(template.widthMm * PRINT_SCALE * 3.78);
+  const height = Math.round(template.heightMm * PRINT_SCALE * 3.78);
+  const elements = template.elements.map(element => {
+    if (isShapeElement(element)) {
+      return svgShape(element);
+    }
+
+    if (element.type === "photo") {
+      const rx = element.shape === "circle" ? `${Math.min(element.width, element.height) / 2}%` : "2%";
+      const initials = attendeeInitials(attendee.displayName);
+      return `<rect x="${element.x}%" y="${element.y}%" width="${element.width}%" height="${element.height}%" rx="${rx}" fill="#e2e8f0"/><text x="${element.x + element.width / 2}%" y="${element.y + element.height / 2}%" text-anchor="middle" dominant-baseline="middle" font-size="${element.fontSize * PRINT_SCALE}" font-weight="700" fill="#334155">${escapeHtml(initials)}</text>`;
+    }
+
+    if (element.type === "qrCode") {
+      return `<rect x="${element.x}%" y="${element.y}%" width="${element.width}%" height="${element.height}%" fill="#fff" stroke="#cbd5e1"/>${renderNestedQrSvg(getBadgeElementValue(element, attendee, eventId), element)}`;
+    }
+
+    return svgText(template, element, getBadgeElementValue(element, attendee, eventId));
+  }).join("");
+
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 100 100" preserveAspectRatio="none"><rect width="100%" height="100%" fill="${escapeAttr(template.background.color || "#ffffff")}"/>${elements}</svg>`;
+  return sharp(Buffer.from(svg)).png().toBuffer();
+}

--- a/src/lib/events/accommodation.ts
+++ b/src/lib/events/accommodation.ts
@@ -1,8 +1,8 @@
-import {
-  type SerializedHotel,
-  type SerializedHotelStayPolicy,
-  type SerializedProduct,
-  type SerializedStayPolicy,
+import type {
+  SerializedHotel,
+  SerializedHotelStayPolicy,
+  SerializedProduct,
+  SerializedStayPolicy,
 } from "@/types/event";
 
 type LegacyStayPolicy = {
@@ -284,4 +284,3 @@ export function calculateMaximumStaySurcharge(
     return Math.max(maxValue, total);
   }, 0);
 }
-

--- a/src/lib/user/profilePicture.test.ts
+++ b/src/lib/user/profilePicture.test.ts
@@ -19,6 +19,11 @@ import { refreshSignedUrls } from "./profilePicture";
 const mockedGetSignedUrl = getSignedUrl as unknown as ReturnType<typeof vi.fn>;
 const mockedUpdatePicture = prisma.profilePicture.update as unknown as ReturnType<typeof vi.fn>;
 
+function signedUrlWithExp(exp: number) {
+    const payload = Buffer.from(JSON.stringify({ exp })).toString("base64url");
+    return `https://cdn.example.com/storage/v1/object/sign/users/user-1/profile.jpg?token=header.${payload}.signature`;
+}
+
 describe("refreshSignedUrls", () => {
     beforeEach(() => {
         vi.clearAllMocks();
@@ -56,5 +61,24 @@ describe("refreshSignedUrls", () => {
                 cachedUntil: expect.any(Date),
             },
         });
+    });
+
+    it("refreshes URLs when the JWT exp is stale even if cachedUntil is in the future", async () => {
+        mockedGetSignedUrl.mockResolvedValue({
+            signedUrl: "https://cdn.example.com/refreshed",
+            expiresIn: 3600,
+        });
+
+        const result = await refreshSignedUrls([
+            {
+                id: "pic-stale-token",
+                storagePath: "users/user-1/stale-token.jpg",
+                signedUrl: signedUrlWithExp(Math.floor(Date.now() / 1000) - 60),
+                cachedUntil: new Date("2099-04-01T10:00:00.000Z"),
+            },
+        ]);
+
+        expect(result[0]?.signedUrl).toBe("https://cdn.example.com/refreshed");
+        expect(mockedGetSignedUrl).toHaveBeenCalledWith("users/user-1/stale-token.jpg", 24 * 60 * 60);
     });
 });

--- a/src/lib/user/profilePicture.ts
+++ b/src/lib/user/profilePicture.ts
@@ -1,8 +1,7 @@
 import { prisma } from "@/lib/prisma/prisma";
 import * as supa from "../supabase";
 
-
-
+const SIGNED_URL_REFRESH_SKEW_MS = 5 * 60 * 1000;
 
 type ProfilePicture = {
     userId: string;
@@ -27,6 +26,31 @@ type RefreshableProfilePicture = {
     cachedUntil: Date | string | null;
 }
 
+function getSignedUrlExpiry(signedUrl: string | null) {
+    if (!signedUrl) return null;
+
+    try {
+        const token = new URL(signedUrl).searchParams.get("token");
+        const payload = token?.split(".")[1];
+        if (!payload) return null;
+
+        const normalized = payload.replaceAll("-", "+").replaceAll("_", "/");
+        const decoded = JSON.parse(Buffer.from(normalized, "base64").toString("utf8")) as { exp?: unknown };
+        return typeof decoded.exp === "number" ? new Date(decoded.exp * 1000) : null;
+    } catch {
+        return null;
+    }
+}
+
+function hasUsableSignedUrl(picture: RefreshableProfilePicture, now: Date) {
+    if (!picture.signedUrl || !picture.cachedUntil || new Date(picture.cachedUntil) <= now) {
+        return false;
+    }
+
+    const tokenExpiry = getSignedUrlExpiry(picture.signedUrl);
+    return !tokenExpiry || tokenExpiry.getTime() > now.getTime() + SIGNED_URL_REFRESH_SKEW_MS;
+}
+
 export async function refreshSignedUrls<T extends RefreshableProfilePicture>(
     profilePictures: T[],
     expiresInSeconds: number = 24 * 60 * 60
@@ -35,7 +59,7 @@ export async function refreshSignedUrls<T extends RefreshableProfilePicture>(
 
     return Promise.all(
         profilePictures.map(async (picture) => {
-            if (picture.signedUrl && picture.cachedUntil && new Date(picture.cachedUntil) > now) {
+            if (hasUsableSignedUrl(picture, now)) {
                 return picture;
             }
 

--- a/src/types/qr-js.d.ts
+++ b/src/types/qr-js.d.ts
@@ -1,0 +1,20 @@
+declare module "qr.js/lib/ErrorCorrectLevel" {
+  const ErrorCorrectLevel: {
+    L: number;
+    M: number;
+    Q: number;
+    H: number;
+  };
+
+  export default ErrorCorrectLevel;
+}
+
+declare module "qr.js/lib/QRCode" {
+  export default class QRCode {
+    modules: boolean[][];
+
+    constructor(typeNumber: number, errorCorrectLevel: number);
+    addData(data: string, mode?: string): void;
+    make(): void;
+  }
+}

--- a/src/types/schemas/badge.ts
+++ b/src/types/schemas/badge.ts
@@ -1,0 +1,98 @@
+import { z } from "zod";
+
+export const BADGE_FIELD_KEYS = [
+  "photo",
+  "displayName",
+  "legalName",
+  "ticketId",
+  "ticketTier",
+  "eventName",
+  "qrCode",
+  "customField",
+  "staticText",
+  "rectangle",
+  "ellipse",
+  "line",
+] as const;
+
+export const badgeFieldKeySchema = z.enum(BADGE_FIELD_KEYS);
+
+export const badgeBackgroundSchema = z
+  .object({
+    color: z.string().min(1).default("#ffffff"),
+    imageUrl: z.string().url().nullable().optional(),
+    fit: z.enum(["cover", "contain", "stretch"]).default("cover"),
+    positionX: z.number().min(0).max(100).default(50),
+    positionY: z.number().min(0).max(100).default(50),
+    fallbackPhotoUrls: z.array(z.string().url()).max(30).default([]),
+  })
+  .strict();
+
+export const badgeElementSchema = z
+  .object({
+    id: z.string().min(1),
+    type: badgeFieldKeySchema,
+    label: z.string().min(1).max(80),
+    x: z.number().min(0).max(100),
+    y: z.number().min(0).max(100),
+    width: z.number().min(1).max(100),
+    height: z.number().min(1).max(100),
+    fontSize: z.number().min(6).max(72).default(14),
+    fontWeight: z.enum(["400", "600", "700"]).default("600"),
+    color: z.string().min(1).default("#111827"),
+    align: z.enum(["left", "center", "right"]).default("left"),
+    staticText: z.string().max(200).optional(),
+    customFieldId: z.string().max(120).optional(),
+    shape: z.enum(["square", "circle"]).default("square"),
+    backgroundColor: z.string().min(1).optional(),
+    borderColor: z.string().min(1).optional(),
+    borderWidth: z.number().min(0).max(20).optional(),
+    customCss: z.string().max(2000).optional(),
+  })
+  .strict();
+
+export const badgeTemplateInputSchema = z
+  .object({
+    name: z.string().min(1, "Template name is required").max(80),
+    isDefault: z.boolean().default(false),
+    widthMm: z.number().min(20).max(300).default(85),
+    heightMm: z.number().min(20).max(300).default(55),
+    background: badgeBackgroundSchema.default({ color: "#ffffff", fit: "cover", positionX: 50, positionY: 50, fallbackPhotoUrls: [] }),
+    elements: z.array(badgeElementSchema).max(40).default([]),
+  })
+  .strict();
+
+export const badgeTemplatePatchSchema = z
+  .object({
+    name: z.string().min(1, "Template name is required").max(80).optional(),
+    isDefault: z.boolean().optional(),
+    widthMm: z.number().min(20).max(300).optional(),
+    heightMm: z.number().min(20).max(300).optional(),
+    background: badgeBackgroundSchema.optional(),
+    elements: z.array(badgeElementSchema).max(40).optional(),
+  })
+  .strict();
+
+export const badgeAttendeeQuerySchema = z
+  .object({
+    status: z.enum(["ALL", "PENDING", "APPROVED", "CONFIRMED", "WAITLISTED"]).default("CONFIRMED"),
+    ticketTier: z.string().optional(),
+    search: z.string().optional(),
+  })
+  .strict();
+
+export const badgeExportSchema = z
+  .object({
+    template: badgeTemplateInputSchema,
+    attendeeIds: z.array(z.string()).min(1).max(250),
+    format: z.enum(["html", "png"]).default("html"),
+    pageMode: z.enum(["sheet", "single"]).default("sheet"),
+  })
+  .strict();
+
+export type BadgeFieldKey = z.infer<typeof badgeFieldKeySchema>;
+export type BadgeBackground = z.infer<typeof badgeBackgroundSchema>;
+export type BadgeElement = z.infer<typeof badgeElementSchema>;
+export type BadgeTemplateInput = z.infer<typeof badgeTemplateInputSchema>;
+export type BadgeAttendeeQuery = z.infer<typeof badgeAttendeeQuerySchema>;
+export type BadgeExportInput = z.infer<typeof badgeExportSchema>;


### PR DESCRIPTION
- add per-event badge templates with Prisma schema and API routes
- add admin badge designer with preview, layers, shapes, custom CSS, background controls, and fallback photo pool
- support attendee filtering, QR rendering, printable HTML, and PNG export
- refresh expired profile picture signed URLs for badge previews
- scope badge templates to event ownership and add isolation tests
- add fallback photo cropping/upload support for attendees without profile pictures
- fit long badge text to avoid clipping in preview/print/export
- fix build font dependency and clean up Biome lint diagnostics

## Summary

## Testing

<!-- ventry:auto-fixes:start -->
Fixes #72
<!-- ventry:auto-fixes:end -->
