### PR TITLE
32 community core community feature for events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,9 @@ next-env.d.ts
 # Snyk Security Extension - AI Rules (auto-generated)
 .github/instructions/snyk_rules.instructions.md
 .playwright-mcp
+/*.json
+!/package.json
+!/package-lock.json
 /*.md
 /.*
 !/.github/

--- a/prisma/migrations/20260615150000_add_event_community/migration.sql
+++ b/prisma/migrations/20260615150000_add_event_community/migration.sql
@@ -1,0 +1,106 @@
+-- CreateEnum
+CREATE TYPE "CommunityPostType" AS ENUM ('TEXT', 'IMAGE', 'LINK', 'FEEDBACK', 'VIDEO');
+
+-- CreateEnum
+CREATE TYPE "PostStatus" AS ENUM ('PENDING', 'APPROVED', 'REJECTED', 'DELETED');
+
+-- CreateEnum
+CREATE TYPE "ModerationAction" AS ENUM ('CREATED', 'APPROVED', 'REJECTED', 'DELETED');
+
+-- AlterTable
+ALTER TABLE "Event"
+ADD COLUMN "communityEnabled" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN "communityOpenAfterEnd" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN "communityModerated" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN "communityAttendeesOnly" BOOLEAN NOT NULL DEFAULT true;
+
+-- CreateTable
+CREATE TABLE "CommunityPost" (
+    "id" TEXT NOT NULL,
+    "eventId" INTEGER NOT NULL,
+    "authorId" TEXT NOT NULL,
+    "type" "CommunityPostType" NOT NULL,
+    "content" TEXT,
+    "imageUrls" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "linkUrl" TEXT,
+    "feedbackRating" INTEGER,
+    "muxAssetId" TEXT,
+    "muxPlaybackId" TEXT,
+    "status" "PostStatus" NOT NULL DEFAULT 'PENDING',
+    "pinned" BOOLEAN NOT NULL DEFAULT false,
+    "deletedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "CommunityPost_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PostReaction" (
+    "id" TEXT NOT NULL,
+    "postId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "reaction" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PostReaction_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PostModerationLog" (
+    "id" TEXT NOT NULL,
+    "postId" TEXT NOT NULL,
+    "actorUserId" TEXT,
+    "actorAdminId" TEXT,
+    "action" "ModerationAction" NOT NULL,
+    "reason" TEXT,
+    "metadata" JSONB NOT NULL DEFAULT '{}',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PostModerationLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "CommunityPost_eventId_status_pinned_createdAt_idx" ON "CommunityPost"("eventId", "status", "pinned", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "CommunityPost_authorId_createdAt_idx" ON "CommunityPost"("authorId", "createdAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PostReaction_postId_userId_reaction_key" ON "PostReaction"("postId", "userId", "reaction");
+
+-- CreateIndex
+CREATE INDEX "PostReaction_postId_idx" ON "PostReaction"("postId");
+
+-- CreateIndex
+CREATE INDEX "PostReaction_userId_idx" ON "PostReaction"("userId");
+
+-- CreateIndex
+CREATE INDEX "PostModerationLog_postId_createdAt_idx" ON "PostModerationLog"("postId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "PostModerationLog_actorUserId_idx" ON "PostModerationLog"("actorUserId");
+
+-- CreateIndex
+CREATE INDEX "PostModerationLog_actorAdminId_idx" ON "PostModerationLog"("actorAdminId");
+
+-- AddForeignKey
+ALTER TABLE "CommunityPost" ADD CONSTRAINT "CommunityPost_eventId_fkey" FOREIGN KEY ("eventId") REFERENCES "Event"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CommunityPost" ADD CONSTRAINT "CommunityPost_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PostReaction" ADD CONSTRAINT "PostReaction_postId_fkey" FOREIGN KEY ("postId") REFERENCES "CommunityPost"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PostReaction" ADD CONSTRAINT "PostReaction_userId_fkey" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PostModerationLog" ADD CONSTRAINT "PostModerationLog_postId_fkey" FOREIGN KEY ("postId") REFERENCES "CommunityPost"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PostModerationLog" ADD CONSTRAINT "PostModerationLog_actorUserId_fkey" FOREIGN KEY ("actorUserId") REFERENCES "user"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PostModerationLog" ADD CONSTRAINT "PostModerationLog_actorAdminId_fkey" FOREIGN KEY ("actorAdminId") REFERENCES "Admin"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20260615162000_add_community_post_tags/migration.sql
+++ b/prisma/migrations/20260615162000_add_community_post_tags/migration.sql
@@ -1,0 +1,19 @@
+-- AlterTable
+ALTER TABLE "CommunityPost"
+ADD COLUMN "tags" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];
+
+-- Backfill tags from existing post shape so filters work for earlier rows.
+UPDATE "CommunityPost"
+SET "tags" =
+  ARRAY[lower("type"::TEXT)] ||
+  CASE
+    WHEN "type" IN ('IMAGE', 'VIDEO') THEN ARRAY['media']::TEXT[]
+    ELSE ARRAY[]::TEXT[]
+  END ||
+  CASE
+    WHEN "feedbackRating" IS NOT NULL THEN ARRAY['rating']::TEXT[]
+    ELSE ARRAY[]::TEXT[]
+  END;
+
+-- CreateIndex
+CREATE INDEX "CommunityPost_tags_idx" ON "CommunityPost" USING GIN ("tags");

--- a/prisma/migrations/20260615171000_add_community_feedback_type/migration.sql
+++ b/prisma/migrations/20260615171000_add_community_feedback_type/migration.sql
@@ -1,0 +1,11 @@
+-- CreateEnum
+CREATE TYPE "CommunityFeedbackType" AS ENUM ('VENUE', 'ORGANIZATION', 'EVENTS', 'OVERALL_EXPERIENCE');
+
+-- AlterTable
+ALTER TABLE "CommunityPost"
+ADD COLUMN "feedbackType" "CommunityFeedbackType";
+
+-- Backfill a default category for existing feedback posts.
+UPDATE "CommunityPost"
+SET "feedbackType" = 'OVERALL_EXPERIENCE'
+WHERE "type" = 'FEEDBACK' AND "feedbackType" IS NULL;

--- a/prisma/migrations/20260615180000_add_community_post_feedback_entries/migration.sql
+++ b/prisma/migrations/20260615180000_add_community_post_feedback_entries/migration.sql
@@ -1,0 +1,14 @@
+-- Add grouped feedback storage to community posts.
+ALTER TABLE "CommunityPost"
+ADD COLUMN "feedbackEntries" JSONB NOT NULL DEFAULT '[]';
+
+-- Backfill existing single feedback posts into the grouped structure.
+UPDATE "CommunityPost"
+SET "feedbackEntries" = jsonb_build_array(
+  jsonb_build_object(
+    'content', "content",
+    'feedbackRating', "feedbackRating",
+    'feedbackType', "feedbackType"
+  )
+)
+WHERE "feedbackType" IS NOT NULL OR "feedbackRating" IS NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -54,6 +54,9 @@ model User {
   pendingAccountLinks  PendingAccountLink[]
   sessions             Session[]
   twofactors           TwoFactor[]
+  communityPosts       CommunityPost[]
+  postReactions        PostReaction[]
+  postModerationLogs   PostModerationLog[] @relation("UserPostModerationLogs")
 
   @@map("user")
 }
@@ -71,6 +74,7 @@ model Admin {
   eventsOwned          Event[]
   history              RegistrationHistory[]
   supportTicketUpdates SupportTicket[]       @relation("AdminSupportTicketUpdates")
+  postModerationLogs   PostModerationLog[]   @relation("AdminPostModerationLogs")
 }
 
 model Account {
@@ -140,6 +144,10 @@ model Event {
   requiresHotel       Boolean         @default(false)
   requireApproval     Boolean         @default(false)
   scanOnce            Boolean         @default(false)
+  communityEnabled    Boolean         @default(false)
+  communityOpenAfterEnd Boolean       @default(true)
+  communityModerated  Boolean         @default(true)
+  communityAttendeesOnly Boolean      @default(true)
   badgeTemplates      BadgeTemplate[]
   owner               Admin?          @relation(fields: [ownerId], references: [id])
   checkInLogs         RegistrationCheckInLog[]
@@ -147,6 +155,67 @@ model Event {
   products            Product[]
   registrations       Registration[]
   supportTickets      SupportTicket[]
+  communityPosts      CommunityPost[]
+}
+
+model CommunityPost {
+  id             String              @id @default(cuid())
+  eventId        Int
+  authorId       String
+  type           CommunityPostType
+  tags           String[]            @default([])
+  content        String?
+  imageUrls      String[]            @default([])
+  linkUrl        String?
+  feedbackRating Int?
+  feedbackType   CommunityFeedbackType?
+  feedbackEntries Json                @default("[]")
+  muxAssetId     String?
+  muxPlaybackId  String?
+  status         PostStatus          @default(PENDING)
+  pinned         Boolean             @default(false)
+  deletedAt      DateTime?
+  createdAt      DateTime            @default(now())
+  updatedAt      DateTime            @updatedAt
+  event          Event               @relation(fields: [eventId], references: [id], onDelete: Cascade)
+  author         User                @relation(fields: [authorId], references: [id], onDelete: Cascade)
+  reactions      PostReaction[]
+  moderationLogs PostModerationLog[]
+
+  @@index([eventId, status, pinned, createdAt])
+  @@index([authorId, createdAt])
+}
+
+model PostReaction {
+  id        String        @id @default(cuid())
+  postId    String
+  userId    String
+  reaction  String
+  createdAt DateTime      @default(now())
+  post      CommunityPost @relation(fields: [postId], references: [id], onDelete: Cascade)
+  user      User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([postId, userId, reaction])
+  @@index([postId])
+  @@index([userId])
+}
+
+model PostModerationLog {
+  id           String           @id @default(cuid())
+  postId       String
+  actorUserId  String?
+  actorAdminId String?
+  action       ModerationAction
+  reason       String?
+  metadata     Json             @default("{}")
+  createdAt    DateTime         @default(now())
+  post         CommunityPost    @relation(fields: [postId], references: [id], onDelete: Cascade)
+  actorUser    User?            @relation("UserPostModerationLogs", fields: [actorUserId], references: [id], onDelete: SetNull)
+  actorAdmin   Admin?           @relation("AdminPostModerationLogs", fields: [actorAdminId], references: [id], onDelete: SetNull)
+
+  @@index([postId, createdAt])
+  @@index([actorUserId])
+  @@index([actorAdminId])
 }
 
 model BadgeTemplate {
@@ -407,4 +476,33 @@ enum SupportTicketStatus {
   IN_PROGRESS
   RESOLVED
   CLOSED
+}
+
+enum CommunityPostType {
+  TEXT
+  IMAGE
+  LINK
+  FEEDBACK
+  VIDEO
+}
+
+enum CommunityFeedbackType {
+  VENUE
+  ORGANIZATION
+  EVENTS
+  OVERALL_EXPERIENCE
+}
+
+enum PostStatus {
+  PENDING
+  APPROVED
+  REJECTED
+  DELETED
+}
+
+enum ModerationAction {
+  CREATED
+  APPROVED
+  REJECTED
+  DELETED
 }

--- a/src/app/api/admin/event/route.ts
+++ b/src/app/api/admin/event/route.ts
@@ -74,6 +74,10 @@ function buildCreateEventArgs(
             },
             requireApproval: validatedData.requireApproval,
             scanOnce: validatedData.scanOnce,
+            communityEnabled: validatedData.communityEnabled ?? false,
+            communityOpenAfterEnd: validatedData.communityOpenAfterEnd ?? true,
+            communityModerated: validatedData.communityModerated ?? true,
+            communityAttendeesOnly: validatedData.communityAttendeesOnly ?? true,
         },
         include: {
             location: true,

--- a/src/app/api/community/media/upload/route.ts
+++ b/src/app/api/community/media/upload/route.ts
@@ -1,0 +1,81 @@
+import { type NextRequest, NextResponse } from "next/server";
+import sharp from "sharp";
+import {
+  CommunityError,
+  assertCanWriteInCommunity,
+  assertCommunityEnabled,
+  loadCommunityActor,
+  loadCommunityEvent,
+} from "@/lib/community/server";
+import { getSession } from "@/lib/auth/session";
+import { getSignedUrl, uploadCommunityImage } from "@/lib/supabase";
+
+const MAX_UPLOAD_BYTES = 6 * 1024 * 1024;
+
+function toErrorResponse(error: unknown) {
+  if (error instanceof CommunityError) {
+    return NextResponse.json({ error: error.message }, { status: error.status });
+  }
+
+  console.error("Error uploading community image:", error);
+  return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const session = await getSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const formData = await req.formData();
+    const eventId = Number(formData.get("eventId"));
+    const file = formData.get("file") as File | null;
+
+    if (Number.isNaN(eventId)) {
+      return NextResponse.json({ error: "Invalid event id" }, { status: 400 });
+    }
+
+    if (!file) {
+      return NextResponse.json({ error: "No file uploaded" }, { status: 400 });
+    }
+
+    if (!file.type.startsWith("image/")) {
+      return NextResponse.json({ error: "Only image uploads are supported" }, { status: 415 });
+    }
+
+    if (file.size > MAX_UPLOAD_BYTES) {
+      return NextResponse.json({ error: "Image must be 6MB or smaller" }, { status: 413 });
+    }
+
+    const actor = await loadCommunityActor(session.user.id);
+    if (!actor) {
+      return NextResponse.json({ error: "User not found" }, { status: 403 });
+    }
+
+    const event = await loadCommunityEvent(eventId);
+    assertCommunityEnabled(event);
+    await assertCanWriteInCommunity(actor, event);
+
+    const bytes = Buffer.from(await file.arrayBuffer());
+    const processedBuffer = await sharp(bytes)
+      .rotate()
+      .resize(1600, 1600, { fit: "inside", withoutEnlargement: true })
+      .toFormat("jpeg", { quality: 82 })
+      .toBuffer();
+
+    const fileName = `community-${Date.now()}-${Math.random().toString(36).slice(2, 10)}.jpg`;
+    const uploadResult = await uploadCommunityImage(processedBuffer, event.id, actor.id, fileName);
+    const signedUrlData = await getSignedUrl(uploadResult.path, 365 * 24 * 60 * 60);
+
+    return NextResponse.json(
+      {
+        url: signedUrlData.signedUrl,
+        path: uploadResult.path,
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    return toErrorResponse(error);
+  }
+}

--- a/src/app/api/community/posts/[postId]/react/route.ts
+++ b/src/app/api/community/posts/[postId]/react/route.ts
@@ -1,0 +1,115 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { PostStatus } from "@/generated/prisma";
+import {
+  CommunityError,
+  assertCanWriteInCommunity,
+  assertCommunityEnabled,
+  communityPostInclude,
+  loadCommunityActor,
+  serializeCommunityPost,
+} from "@/lib/community/server";
+import { getSession } from "@/lib/auth/session";
+import { prisma } from "@/lib/prisma/prisma";
+import { reactToCommunityPostSchema } from "@/types/schemas/community";
+
+function toErrorResponse(error: unknown) {
+  if (error instanceof CommunityError) {
+    return NextResponse.json({ error: error.message }, { status: error.status });
+  }
+
+  console.error("Error reacting to community post:", error);
+  return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ postId: string }> },
+) {
+  try {
+    const session = await getSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await req.json();
+    const parsed = reactToCommunityPostSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.issues }, { status: 422 });
+    }
+
+    const actor = await loadCommunityActor(session.user.id);
+    if (!actor) {
+      return NextResponse.json({ error: "User not found" }, { status: 403 });
+    }
+
+    const { postId } = await params;
+    const post = await prisma.communityPost.findFirst({
+      where: {
+        id: postId,
+        status: PostStatus.APPROVED,
+      },
+      select: {
+        id: true,
+        event: {
+          select: {
+            id: true,
+            ownerId: true,
+            endDate: true,
+            communityEnabled: true,
+            communityOpenAfterEnd: true,
+            communityModerated: true,
+            communityAttendeesOnly: true,
+          },
+        },
+      },
+    });
+
+    if (!post) {
+      return NextResponse.json({ error: "Community post not found" }, { status: 404 });
+    }
+
+    assertCommunityEnabled(post.event);
+    await assertCanWriteInCommunity(actor, post.event);
+
+    const existing = await prisma.postReaction.findUnique({
+      where: {
+        postId_userId_reaction: {
+          postId: post.id,
+          userId: actor.id,
+          reaction: parsed.data.reaction,
+        },
+      },
+      select: { id: true },
+    });
+
+    if (existing) {
+      await prisma.postReaction.delete({
+        where: { id: existing.id },
+      });
+    } else {
+      await prisma.postReaction.create({
+        data: {
+          postId: post.id,
+          userId: actor.id,
+          reaction: parsed.data.reaction,
+        },
+      });
+    }
+
+    const updatedPost = await prisma.communityPost.findUniqueOrThrow({
+      where: { id: post.id },
+      include: communityPostInclude,
+    });
+    const serialized = serializeCommunityPost(updatedPost, actor.id);
+
+    return NextResponse.json(
+      {
+        reactions: serialized.reactions,
+        viewerReactions: serialized.viewerReactions,
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    return toErrorResponse(error);
+  }
+}

--- a/src/app/api/community/posts/[postId]/route.ts
+++ b/src/app/api/community/posts/[postId]/route.ts
@@ -1,0 +1,64 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { PostStatus } from "@/generated/prisma";
+import {
+  CommunityError,
+  assertCanDeletePost,
+  loadCommunityActor,
+  softDeletePost,
+} from "@/lib/community/server";
+import { getSession } from "@/lib/auth/session";
+import { prisma } from "@/lib/prisma/prisma";
+
+function toErrorResponse(error: unknown) {
+  if (error instanceof CommunityError) {
+    return NextResponse.json({ error: error.message }, { status: error.status });
+  }
+
+  console.error("Error deleting community post:", error);
+  return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+}
+
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ postId: string }> },
+) {
+  try {
+    const session = await getSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const actor = await loadCommunityActor(session.user.id);
+    if (!actor) {
+      return NextResponse.json({ error: "User not found" }, { status: 403 });
+    }
+
+    const { postId } = await params;
+    const post = await prisma.communityPost.findFirst({
+      where: {
+        id: postId,
+        status: { not: PostStatus.DELETED },
+      },
+      select: {
+        id: true,
+        authorId: true,
+        event: {
+          select: {
+            ownerId: true,
+          },
+        },
+      },
+    });
+
+    if (!post) {
+      return NextResponse.json({ error: "Community post not found" }, { status: 404 });
+    }
+
+    assertCanDeletePost(actor, post);
+    await softDeletePost({ postId: post.id, actor });
+
+    return NextResponse.json({ deleted: true }, { status: 200 });
+  } catch (error) {
+    return toErrorResponse(error);
+  }
+}

--- a/src/app/api/community/posts/route.test.ts
+++ b/src/app/api/community/posts/route.test.ts
@@ -1,0 +1,395 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/prisma/prisma", () => ({
+  prisma: {
+    user: {
+      findUnique: vi.fn(),
+    },
+    event: {
+      findUnique: vi.fn(),
+    },
+    registration: {
+      findFirst: vi.fn(),
+    },
+    communityPost: {
+      findMany: vi.fn(),
+      create: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  getSession: vi.fn(),
+}));
+
+import * as postsRoute from "./route";
+import { prisma } from "@/lib/prisma/prisma";
+import { getSession } from "@/lib/auth/session";
+
+const mockedGetSession = getSession as unknown as ReturnType<typeof vi.fn>;
+const mockedFindUser = prisma.user.findUnique as unknown as ReturnType<typeof vi.fn>;
+const mockedFindEvent = prisma.event.findUnique as unknown as ReturnType<typeof vi.fn>;
+const mockedFindRegistration = prisma.registration.findFirst as unknown as ReturnType<typeof vi.fn>;
+const mockedFindPosts = prisma.communityPost.findMany as unknown as ReturnType<typeof vi.fn>;
+const mockedCreatePost = prisma.communityPost.create as unknown as ReturnType<typeof vi.fn>;
+
+function getRequest(url: string) {
+  return new NextRequest(url, { method: "GET" });
+}
+
+function postRequest(url: string, body: unknown) {
+  return new NextRequest(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function communityEvent(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 7,
+    ownerId: "admin-owner",
+    endDate: new Date("2026-07-01T10:00:00.000Z"),
+    communityEnabled: true,
+    communityOpenAfterEnd: true,
+    communityModerated: true,
+    communityAttendeesOnly: true,
+    ...overrides,
+  };
+}
+
+function includedPost(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "post-1",
+    eventId: 7,
+    authorId: "user-1",
+    type: "TEXT",
+    tags: ["text"],
+    content: "Hello community",
+    imageUrls: [],
+    linkUrl: null,
+    feedbackRating: null,
+    feedbackType: null,
+    feedbackEntries: [],
+    status: "APPROVED",
+    pinned: false,
+    createdAt: new Date("2026-06-15T12:00:00.000Z"),
+    updatedAt: new Date("2026-06-15T12:00:00.000Z"),
+    author: {
+      id: "user-1",
+      name: "Jamie",
+      image: null,
+      profilePictures: [],
+    },
+    reactions: [
+      { userId: "user-1", reaction: "LIKE" },
+      { userId: "user-2", reaction: "LOVE" },
+    ],
+    ...overrides,
+  };
+}
+
+describe("App Router: /api/community/posts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedFindEvent.mockResolvedValue(communityEvent());
+    mockedFindUser.mockResolvedValue({
+      id: "user-1",
+      isAdmin: false,
+      adminProfile: null,
+    });
+  });
+
+  describe("GET", () => {
+    it("lists approved community posts with reaction counts", async () => {
+      mockedGetSession.mockResolvedValue({ user: { id: "user-1" } });
+      mockedFindPosts.mockResolvedValue([includedPost()]);
+
+      const response = await postsRoute.GET(
+        getRequest("http://localhost/api/community/posts?eventId=7&limit=20"),
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({
+        posts: [
+          expect.objectContaining({
+            id: "post-1",
+            tags: ["text"],
+            author: {
+              id: "user-1",
+              name: "Jamie",
+              imageUrl: null,
+            },
+            reactions: {
+              LIKE: 1,
+              LOVE: 1,
+              CELEBRATE: 0,
+              HELPFUL: 0,
+            },
+            viewerReactions: ["LIKE"],
+          }),
+        ],
+        nextCursor: null,
+      });
+      expect(mockedFindPosts).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            eventId: 7,
+            status: "APPROVED",
+          },
+        }),
+      );
+    });
+
+    it("returns 403 when community is disabled", async () => {
+      mockedGetSession.mockResolvedValue(null);
+      mockedFindEvent.mockResolvedValue(communityEvent({ communityEnabled: false }));
+
+      const response = await postsRoute.GET(
+        getRequest("http://localhost/api/community/posts?eventId=7"),
+      );
+
+      expect(response.status).toBe(403);
+      expect(await response.json()).toEqual({ error: "Community is disabled for this event" });
+    });
+  });
+
+  describe("POST", () => {
+    it("returns 401 when the user is not signed in", async () => {
+      mockedGetSession.mockResolvedValue(null);
+
+      const response = await postsRoute.POST(
+        postRequest("http://localhost/api/community/posts", {
+          eventId: 7,
+          type: "TEXT",
+          content: "Hello",
+        }),
+      );
+
+      expect(response.status).toBe(401);
+      expect(mockedCreatePost).not.toHaveBeenCalled();
+    });
+
+    it("blocks non-attendees when attendee-only mode is enabled", async () => {
+      mockedGetSession.mockResolvedValue({ user: { id: "user-1" } });
+      mockedFindRegistration.mockResolvedValue(null);
+
+      const response = await postsRoute.POST(
+        postRequest("http://localhost/api/community/posts", {
+          eventId: 7,
+          type: "TEXT",
+          content: "Hello",
+        }),
+      );
+
+      expect(response.status).toBe(403);
+      expect(await response.json()).toEqual({
+        error: "Only attendees can post in this event community",
+      });
+      expect(mockedCreatePost).not.toHaveBeenCalled();
+    });
+
+    it("creates pending posts when moderation is enabled", async () => {
+      mockedGetSession.mockResolvedValue({ user: { id: "user-1" } });
+      mockedFindRegistration.mockResolvedValue({ id: "reg-1" });
+      mockedCreatePost.mockResolvedValue(includedPost({ status: "PENDING" }));
+
+      const response = await postsRoute.POST(
+        postRequest("http://localhost/api/community/posts", {
+          eventId: 7,
+          type: "TEXT",
+          content: "Hello community",
+        }),
+      );
+
+      expect(response.status).toBe(201);
+      expect(await response.json()).toEqual({
+        post: expect.objectContaining({
+          id: "post-1",
+          status: "PENDING",
+        }),
+        pending: true,
+      });
+      expect(mockedCreatePost).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            eventId: 7,
+            authorId: "user-1",
+            tags: ["text"],
+            status: "PENDING",
+          }),
+        }),
+      );
+    });
+
+    it("creates feedback posts with a typed feedback category and derived tags", async () => {
+      mockedGetSession.mockResolvedValue({ user: { id: "user-1" } });
+      mockedFindRegistration.mockResolvedValue({ id: "reg-1" });
+      mockedCreatePost.mockResolvedValue(includedPost({
+        type: "FEEDBACK",
+        tags: ["feedback", "feedback:venue", "rating"],
+        content: "The room setup worked well.",
+        feedbackRating: 4,
+        feedbackType: "VENUE",
+        status: "APPROVED",
+      }));
+      mockedFindEvent.mockResolvedValue(communityEvent({ communityModerated: false }));
+
+      const response = await postsRoute.POST(
+        postRequest("http://localhost/api/community/posts", {
+          eventId: 7,
+          type: "FEEDBACK",
+          content: "The room setup worked well.",
+          feedbackRating: 4,
+          feedbackType: "VENUE",
+        }),
+      );
+
+      expect(response.status).toBe(201);
+      expect(await response.json()).toEqual({
+        post: expect.objectContaining({
+          type: "FEEDBACK",
+          tags: ["feedback", "feedback:venue", "rating"],
+          feedbackRating: 4,
+          feedbackType: "VENUE",
+        }),
+        pending: false,
+      });
+      expect(mockedCreatePost).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            feedbackRating: 4,
+            feedbackType: "VENUE",
+            feedbackEntries: [
+              expect.objectContaining({
+                feedbackType: "VENUE",
+                feedbackRating: 4,
+              }),
+            ],
+            tags: ["feedback", "feedback:venue", "rating"],
+          }),
+        }),
+      );
+    });
+
+    it("appends multiple feedback items to the same post payload", async () => {
+      mockedGetSession.mockResolvedValue({ user: { id: "user-1" } });
+      mockedFindRegistration.mockResolvedValue({ id: "reg-1" });
+      mockedCreatePost.mockResolvedValue(includedPost({
+        type: "IMAGE",
+        imageUrls: ["https://cdn.example.com/post.jpg"],
+        feedbackEntries: [
+          {
+            content: "Great venue setup.",
+            feedbackRating: 5,
+            feedbackType: "VENUE",
+          },
+          {
+            content: "The schedule was easy to follow.",
+            feedbackRating: 4,
+            feedbackType: "EVENTS",
+          },
+        ],
+        tags: ["feedback", "feedback:venue", "feedback:events", "image", "media", "rating"],
+        status: "APPROVED",
+      }));
+      mockedFindEvent.mockResolvedValue(communityEvent({ communityModerated: false }));
+
+      const response = await postsRoute.POST(
+        postRequest("http://localhost/api/community/posts", {
+          eventId: 7,
+          type: "IMAGE",
+          content: "Conference recap",
+          imageUrls: ["https://cdn.example.com/post.jpg"],
+          feedbacks: [
+            {
+              content: "Great venue setup.",
+              feedbackRating: 5,
+              feedbackType: "VENUE",
+            },
+            {
+              content: "The schedule was easy to follow.",
+              feedbackRating: 4,
+              feedbackType: "EVENTS",
+            },
+          ],
+        }),
+      );
+
+      expect(response.status).toBe(201);
+      expect(await response.json()).toEqual({
+        post: expect.objectContaining({
+          type: "IMAGE",
+          imageUrls: ["https://cdn.example.com/post.jpg"],
+          feedbacks: [
+            expect.objectContaining({
+              feedbackType: "VENUE",
+              rating: 5,
+            }),
+            expect.objectContaining({
+              feedbackType: "EVENTS",
+              rating: 4,
+            }),
+          ],
+        }),
+        pending: false,
+      });
+      expect(mockedCreatePost).toHaveBeenCalledTimes(1);
+      expect(mockedCreatePost).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: "IMAGE",
+            content: "Conference recap",
+            imageUrls: ["https://cdn.example.com/post.jpg"],
+            feedbackEntries: [
+              expect.objectContaining({
+                feedbackType: "VENUE",
+                feedbackRating: 5,
+              }),
+              expect.objectContaining({
+                feedbackType: "EVENTS",
+                feedbackRating: 4,
+              }),
+            ],
+            tags: ["feedback", "feedback:events", "feedback:venue", "image", "media", "rating"],
+          }),
+        }),
+      );
+    });
+
+    it("lets event owners bypass attendee-only mode", async () => {
+      mockedGetSession.mockResolvedValue({ user: { id: "owner-user" } });
+      mockedFindUser.mockResolvedValue({
+        id: "owner-user",
+        isAdmin: false,
+        adminProfile: { id: "admin-owner" },
+      });
+      mockedCreatePost.mockResolvedValue(includedPost({
+        authorId: "owner-user",
+        status: "APPROVED",
+      }));
+      mockedFindEvent.mockResolvedValue(communityEvent({ communityModerated: false }));
+
+      const response = await postsRoute.POST(
+        postRequest("http://localhost/api/community/posts", {
+          eventId: 7,
+          type: "TEXT",
+          content: "Organizer update",
+        }),
+      );
+
+      expect(response.status).toBe(201);
+      expect(mockedFindRegistration).not.toHaveBeenCalled();
+      expect(mockedCreatePost).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            authorId: "owner-user",
+            tags: ["text"],
+            status: "APPROVED",
+          }),
+        }),
+      );
+    });
+  });
+});

--- a/src/app/api/community/posts/route.ts
+++ b/src/app/api/community/posts/route.ts
@@ -1,0 +1,155 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { ModerationAction, PostStatus } from "@/generated/prisma";
+import {
+  CommunityError,
+  assertCanWriteInCommunity,
+  assertCommunityEnabled,
+  communityPostInclude,
+  deriveCommunityPostTags,
+  loadCommunityActor,
+  loadCommunityEvent,
+  serializeCommunityPost,
+} from "@/lib/community/server";
+import { getSession } from "@/lib/auth/session";
+import { prisma } from "@/lib/prisma/prisma";
+import { createCommunityPostSchema, listCommunityPostsSchema } from "@/types/schemas/community";
+
+function toErrorResponse(error: unknown, logMessage: string) {
+  if (error instanceof CommunityError) {
+    return NextResponse.json({ error: error.message }, { status: error.status });
+  }
+
+  console.error(logMessage, error);
+  return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+}
+
+export async function GET(req: NextRequest) {
+  try {
+    const params = Object.fromEntries(new URL(req.url).searchParams);
+    const parsed = listCommunityPostsSchema.safeParse(params);
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.issues }, { status: 422 });
+    }
+
+    const session = await getSession();
+    const event = await loadCommunityEvent(parsed.data.eventId);
+    assertCommunityEnabled(event);
+
+    const posts = await prisma.communityPost.findMany({
+      where: {
+        eventId: event.id,
+        status: PostStatus.APPROVED,
+      },
+      include: communityPostInclude,
+      orderBy: [
+        { pinned: "desc" },
+        { createdAt: "desc" },
+        { id: "desc" },
+      ],
+      take: parsed.data.limit + 1,
+      ...(parsed.data.cursor
+        ? {
+            cursor: { id: parsed.data.cursor },
+            skip: 1,
+          }
+        : {}),
+    });
+
+    const hasMore = posts.length > parsed.data.limit;
+    const page = hasMore ? posts.slice(0, parsed.data.limit) : posts;
+
+    return NextResponse.json(
+      {
+        posts: page.map(post => serializeCommunityPost(post, session?.user?.id)),
+        nextCursor: hasMore ? page[page.length - 1]?.id || null : null,
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    return toErrorResponse(error, "Error listing community posts:");
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const session = await getSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await req.json();
+    const parsed = createCommunityPostSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.issues }, { status: 422 });
+    }
+
+    const actor = await loadCommunityActor(session.user.id);
+    if (!actor) {
+      return NextResponse.json({ error: "User not found" }, { status: 403 });
+    }
+
+    const event = await loadCommunityEvent(parsed.data.eventId);
+    assertCommunityEnabled(event);
+    await assertCanWriteInCommunity(actor, event);
+    const imageUrls = parsed.data.type === "IMAGE" ? parsed.data.imageUrls : [];
+    const linkUrl = parsed.data.type === "LINK" ? parsed.data.linkUrl || null : null;
+    const feedbacks = parsed.data.feedbacks.length > 0
+      ? parsed.data.feedbacks.map(feedback => ({
+          content: feedback.content || null,
+          feedbackRating: feedback.feedbackRating ?? null,
+          feedbackType: feedback.feedbackType,
+        }))
+      : parsed.data.type === "FEEDBACK" && parsed.data.feedbackType
+        ? [
+            {
+              content: parsed.data.content || null,
+              feedbackRating: parsed.data.feedbackRating ?? null,
+              feedbackType: parsed.data.feedbackType,
+            },
+          ]
+        : [];
+    const primaryFeedback = feedbacks[0] || null;
+
+    const post = await prisma.communityPost.create({
+      data: {
+        eventId: event.id,
+        authorId: actor.id,
+        type: parsed.data.type,
+        tags: deriveCommunityPostTags({
+          type: parsed.data.type,
+          imageUrls,
+          linkUrl,
+          feedbacks,
+          feedbackRating: primaryFeedback?.feedbackRating ?? null,
+          feedbackType: primaryFeedback?.feedbackType ?? null,
+        }),
+        content: parsed.data.content || null,
+        imageUrls,
+        linkUrl,
+        feedbackRating: primaryFeedback?.feedbackRating ?? null,
+        feedbackType: primaryFeedback?.feedbackType ?? null,
+        feedbackEntries: feedbacks,
+        status: event.communityModerated ? PostStatus.PENDING : PostStatus.APPROVED,
+        moderationLogs: {
+          create: {
+            actorUserId: actor.id,
+            actorAdminId: actor.adminId,
+            action: ModerationAction.CREATED,
+            metadata: {},
+          },
+        },
+      },
+      include: communityPostInclude,
+    });
+
+    return NextResponse.json(
+      {
+        post: serializeCommunityPost(post, actor.id),
+        pending: post.status === PostStatus.PENDING,
+      },
+      { status: 201 },
+    );
+  } catch (error) {
+    return toErrorResponse(error, "Error creating community post:");
+  }
+}

--- a/src/app/events/[id]/page.tsx
+++ b/src/app/events/[id]/page.tsx
@@ -30,6 +30,7 @@ import RegistrationCountdown from "@/components/events/RegistrationCountdown";
 import EventSchedule from "@/components/events/EventSchedule";
 import EventLocationMap from "@/components/events/EventLocationMap";
 import SupportTicketPanel from "@/components/events/SupportTicketPanel";
+import CommunitySection from "@/components/events/community/CommunitySection";
 import type { SerializedEvent, SerializedProduct } from "@/types/event";
 import { Suspense } from "react";
 import PageLoadingState from "@/components/common/PageLoadingState";
@@ -147,6 +148,7 @@ async function EventDetailPageContent({
 
   const startDate = new Date(event.startDate);
   const endDate = new Date(event.endDate);
+  const eventEnded = endDate.getTime() < Date.now();
   const serializedProducts = event.products.map(p => ({
     id: p.id,
     name: p.name,
@@ -361,6 +363,18 @@ async function EventDetailPageContent({
                 )}
               </Paper>
             </Box>
+
+            {event.communityEnabled && (
+              <Box mb={6}>
+                <CommunitySection
+                  eventId={event.id}
+                  eventEnded={eventEnded}
+                  communityOpenAfterEnd={event.communityOpenAfterEnd}
+                  currentUserId={session?.user?.id || null}
+                  canModerate={canEdit}
+                />
+              </Box>
+            )}
           </Grid>
 
           {/* Registration Sidebar */}

--- a/src/components/admin/events/EventForm.tsx
+++ b/src/components/admin/events/EventForm.tsx
@@ -50,6 +50,10 @@ export interface InitialData {
   requiresHotel?: boolean;
   requireApproval?: boolean;
   scanOnce?: boolean;
+  communityEnabled?: boolean;
+  communityOpenAfterEnd?: boolean;
+  communityModerated?: boolean;
+  communityAttendeesOnly?: boolean;
   paymentDeadline?: string | Date | null;
   status?: "DRAFT" | "PUBLISHED" | "CANCELLED";
   imageUrl?: string | null;
@@ -213,6 +217,10 @@ export default function EventForm({ initialData, onSubmit, loading: externalLoad
       requiresHotel: initialData?.requiresHotel || false,
       requireApproval: initialData?.requireApproval || false,
       scanOnce: initialData?.scanOnce || false,
+      communityEnabled: initialData?.communityEnabled || false,
+      communityOpenAfterEnd: initialData?.communityOpenAfterEnd ?? true,
+      communityModerated: initialData?.communityModerated ?? true,
+      communityAttendeesOnly: initialData?.communityAttendeesOnly ?? true,
       paymentDeadline: initialData?.paymentDeadline ? new Date(initialData.paymentDeadline) : null,
       status: initialData?.status || "DRAFT",
       imageUrl: initialData?.imageUrl || null,
@@ -268,6 +276,7 @@ export default function EventForm({ initialData, onSubmit, loading: externalLoad
   const watchEndDate = watch("endDate") as Date | string | undefined;
   const watchImageUrl = watch("imageUrl");
   const watchRequiresHotel = watch("requiresHotel") as boolean | undefined;
+  const watchCommunityEnabled = watch("communityEnabled") as boolean | undefined;
   const sensors = useSensors(
     useSensor(PointerSensor),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
@@ -1140,6 +1149,95 @@ export default function EventForm({ initialData, onSubmit, loading: externalLoad
                   Regardless of this setting, the UI will always show how many times a ticket has been scanned.
                 </Typography>
               </Box>
+
+              <Divider />
+              <Typography variant="h6">Community</Typography>
+
+              <Box>
+                <FormControlLabel
+                  control={
+                    <Controller
+                      name="communityEnabled"
+                      control={control}
+                      render={({ field }) => (
+                        <Switch checked={field.value} onChange={event => field.onChange(event.target.checked)} />
+                      )}
+                    />
+                  }
+                  label="Enable community feed"
+                />
+                <Typography variant="caption" display="block" color="text.secondary">
+                  Adds a community section to the event page where attendees and organizers can post updates.
+                </Typography>
+              </Box>
+
+              <Grid container spacing={2}>
+                <Grid size={{ xs: 12, md: 4 }}>
+                  <FormControlLabel
+                    control={
+                      <Controller
+                        name="communityModerated"
+                        control={control}
+                        render={({ field }) => (
+                          <Switch
+                            checked={field.value}
+                            disabled={!watchCommunityEnabled}
+                            onChange={event => field.onChange(event.target.checked)}
+                          />
+                        )}
+                      />
+                    }
+                    label="Moderate new posts"
+                  />
+                  <Typography variant="caption" display="block" color="text.secondary">
+                    New posts stay pending until approved by a future moderation workflow.
+                  </Typography>
+                </Grid>
+
+                <Grid size={{ xs: 12, md: 4 }}>
+                  <FormControlLabel
+                    control={
+                      <Controller
+                        name="communityAttendeesOnly"
+                        control={control}
+                        render={({ field }) => (
+                          <Switch
+                            checked={field.value}
+                            disabled={!watchCommunityEnabled}
+                            onChange={event => field.onChange(event.target.checked)}
+                          />
+                        )}
+                      />
+                    }
+                    label="Attendees only"
+                  />
+                  <Typography variant="caption" display="block" color="text.secondary">
+                    Restricts posting and reactions to active attendees, event owners, and admins.
+                  </Typography>
+                </Grid>
+
+                <Grid size={{ xs: 12, md: 4 }}>
+                  <FormControlLabel
+                    control={
+                      <Controller
+                        name="communityOpenAfterEnd"
+                        control={control}
+                        render={({ field }) => (
+                          <Switch
+                            checked={field.value}
+                            disabled={!watchCommunityEnabled}
+                            onChange={event => field.onChange(event.target.checked)}
+                          />
+                        )}
+                      />
+                    }
+                    label="Open after event ends"
+                  />
+                  <Typography variant="caption" display="block" color="text.secondary">
+                    Allows new posts and reactions after the event end date.
+                  </Typography>
+                </Grid>
+              </Grid>
 
               <Box>
                 <Typography variant="subtitle2" gutterBottom>Event Banner</Typography>

--- a/src/components/events/community/CommunityComposer.tsx
+++ b/src/components/events/community/CommunityComposer.tsx
@@ -1,0 +1,452 @@
+"use client";
+
+import { type ChangeEvent, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  FormControl,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Paper,
+  Rating,
+  Select,
+  Stack,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import { AddPhotoAlternate, Delete, RateReview, Send, Videocam } from "@mui/icons-material";
+import type { CommunityPostView } from "./types";
+
+type FeedbackType = "VENUE" | "ORGANIZATION" | "EVENTS" | "OVERALL_EXPERIENCE";
+
+type ImageDraft = {
+  id: string;
+  file: File;
+  previewUrl: string;
+};
+
+type VideoDraft = {
+  id: string;
+};
+
+type FeedbackDraft = {
+  id: string;
+  content: string;
+  rating: number | null;
+  feedbackType: FeedbackType;
+};
+
+const MAX_DRAFTS_PER_KIND = 5;
+
+const feedbackLabels: Record<FeedbackType, string> = {
+  VENUE: "Venue",
+  ORGANIZATION: "Organization",
+  EVENTS: "Events",
+  OVERALL_EXPERIENCE: "Overall experience",
+};
+const feedbackTypes = Object.keys(feedbackLabels) as FeedbackType[];
+
+function createDraftId(prefix: string) {
+  return `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function getErrorMessage(raw: unknown, fallback: string) {
+  if (!raw || typeof raw !== "object") {
+    return fallback;
+  }
+
+  const payload = raw as {
+    error?: string | Array<{ message?: string }>;
+  };
+
+  if (typeof payload.error === "string") {
+    return payload.error;
+  }
+
+  if (Array.isArray(payload.error)) {
+    return payload.error[0]?.message || fallback;
+  }
+
+  return fallback;
+}
+
+interface CommunityComposerProps {
+  eventId: number;
+  disabledReason?: string | null;
+  onPostCreated: (post: CommunityPostView, pending: boolean) => void;
+}
+
+export default function CommunityComposer({ eventId, disabledReason, onPostCreated }: CommunityComposerProps) {
+  const [content, setContent] = useState("");
+  const [imageDrafts, setImageDrafts] = useState<ImageDraft[]>([]);
+  const [videoDrafts, setVideoDrafts] = useState<VideoDraft[]>([]);
+  const [feedbackDrafts, setFeedbackDrafts] = useState<FeedbackDraft[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const resetDrafts = () => {
+    setContent("");
+    imageDrafts.forEach(draft => URL.revokeObjectURL(draft.previewUrl));
+    setImageDrafts([]);
+    setVideoDrafts([]);
+    setFeedbackDrafts([]);
+  };
+
+  const addVideoDraft = () => {
+    if (videoDrafts.length >= MAX_DRAFTS_PER_KIND) return;
+    setVideoDrafts(current => [...current, { id: createDraftId("video") }]);
+    setNotice(null);
+    setError("Video upload is not available yet. Remove video drafts before posting.");
+  };
+
+  const addFeedbackDraft = () => {
+    const usedFeedbackTypes = new Set(feedbackDrafts.map(draft => draft.feedbackType));
+    const nextFeedbackType = feedbackTypes.find(type => !usedFeedbackTypes.has(type));
+    if (!nextFeedbackType) return;
+
+    setFeedbackDrafts(current => [...current, {
+      id: createDraftId("feedback"),
+      content: "",
+      rating: 5,
+      feedbackType: nextFeedbackType,
+    }]);
+  };
+
+  const handleImageSelect = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    event.target.value = "";
+    if (!file || imageDrafts.length >= MAX_DRAFTS_PER_KIND) return;
+
+    setError(null);
+    setNotice(null);
+    setImageDrafts(current => [
+      ...current,
+      {
+        id: createDraftId("image"),
+        file,
+        previewUrl: URL.createObjectURL(file),
+      },
+    ]);
+  };
+
+  const hasTextPost = content.trim().length > 0;
+  const readyFeedbackDrafts = feedbackDrafts.filter(draft => draft.content.trim().length > 0 || draft.rating);
+  const hasIncompleteFeedbackDraft = feedbackDrafts.some(draft => draft.content.trim().length === 0 && !draft.rating);
+  const hasMainPost = hasTextPost || imageDrafts.length > 0;
+  const draftCount = hasMainPost || readyFeedbackDrafts.length > 0 ? 1 : 0;
+  const submitDisabled = Boolean(disabledReason)
+    || loading
+    || uploading
+    || draftCount === 0
+    || hasIncompleteFeedbackDraft
+    || videoDrafts.length > 0;
+
+  const createPost = async (body: Record<string, unknown>) => {
+    const response = await fetch("/api/community/posts", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        eventId,
+        ...body,
+      }),
+    });
+    const payload = (await response.json().catch(() => null)) as {
+      post?: CommunityPostView;
+      pending?: boolean;
+      error?: unknown;
+    } | null;
+
+    if (!response.ok || !payload?.post) {
+      throw new Error(getErrorMessage(payload, "Failed to create community post"));
+    }
+
+    onPostCreated(payload.post, Boolean(payload.pending));
+    return Boolean(payload.pending);
+  };
+
+  const uploadImageDraft = async (draft: ImageDraft) => {
+    const formData = new FormData();
+    formData.append("eventId", String(eventId));
+    formData.append("file", draft.file);
+
+    const response = await fetch("/api/community/media/upload", {
+      method: "POST",
+      body: formData,
+    });
+    const payload = (await response.json().catch(() => null)) as { url?: string; error?: unknown } | null;
+
+    if (!response.ok || !payload?.url) {
+      throw new Error(getErrorMessage(payload, "Failed to upload image"));
+    }
+
+    return payload.url;
+  };
+
+  const handleSubmit = async () => {
+    if (submitDisabled) return;
+
+    setError(null);
+    setNotice(null);
+    setLoading(true);
+
+    try {
+      const feedbacks = readyFeedbackDrafts.map(draft => ({
+        content: draft.content,
+        feedbackRating: draft.rating ?? undefined,
+        feedbackType: draft.feedbackType,
+      }));
+
+      let pending = false;
+      if (imageDrafts.length > 0) {
+        setUploading(true);
+        const imageUrls = [];
+        for (const draft of imageDrafts) {
+          imageUrls.push(await uploadImageDraft(draft));
+        }
+        pending = await createPost({
+          type: "IMAGE",
+          content: hasTextPost ? content.trim() : undefined,
+          imageUrls,
+          feedbacks,
+        });
+      } else if (hasTextPost) {
+        pending = await createPost({
+          type: "TEXT",
+          content: content.trim(),
+          feedbacks,
+        });
+      } else if (feedbacks.length > 0) {
+        pending = await createPost({
+          type: "FEEDBACK",
+          feedbacks,
+        });
+      }
+
+      resetDrafts();
+      setNotice(pending ? "Post submitted and pending moderation." : "Post submitted.");
+    } catch (submitError) {
+      setError(submitError instanceof Error ? submitError.message : "Failed to create community posts");
+    } finally {
+      setUploading(false);
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Box>
+      {disabledReason ? <Alert severity="info" sx={{ mb: 2 }}>{disabledReason}</Alert> : null}
+      {error ? <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert> : null}
+      {notice ? <Alert severity="success" sx={{ mb: 2 }}>{notice}</Alert> : null}
+
+      <Stack spacing={2}>
+        <TextField
+          fullWidth
+          multiline
+          minRows={3}
+          label="What's happening?"
+          value={content}
+          onChange={event => setContent(event.target.value)}
+          disabled={Boolean(disabledReason)}
+        />
+
+        {imageDrafts.length > 0 ? (
+          <Box
+            sx={{
+              display: "grid",
+              gridTemplateColumns: { xs: "1fr", sm: "repeat(2, minmax(0, 1fr))" },
+              gap: 1.5,
+            }}
+          >
+            {imageDrafts.map((draft, index) => (
+              <Paper key={draft.id} variant="outlined" sx={{ p: 1.5 }}>
+                <Stack spacing={1}>
+                  <Stack direction="row" justifyContent="space-between" alignItems="center">
+                    <Typography variant="subtitle2">Image {index + 1}</Typography>
+                    <IconButton
+                      aria-label={`Remove image ${index + 1}`}
+                      color="error"
+                      size="small"
+                onClick={() => {
+                  URL.revokeObjectURL(draft.previewUrl);
+                  setImageDrafts(current => current.filter(item => item.id !== draft.id));
+                }}
+                    >
+                      <Delete fontSize="small" />
+                    </IconButton>
+                  </Stack>
+                  <Box
+                    sx={{
+                      position: "relative",
+                      width: "100%",
+                      aspectRatio: "4 / 3",
+                      overflow: "hidden",
+                      borderRadius: 1,
+                      bgcolor: "grey.100",
+                    }}
+                  >
+                    <Box
+                      component="img"
+                      src={draft.previewUrl}
+                      alt={`Selected community image ${index + 1}`}
+                      sx={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }}
+                    />
+                  </Box>
+                </Stack>
+              </Paper>
+            ))}
+          </Box>
+        ) : null}
+
+        {videoDrafts.map((draft, index) => (
+          <Paper key={draft.id} variant="outlined" sx={{ p: 2 }}>
+            <Stack direction="row" spacing={2} alignItems="center" justifyContent="space-between">
+              <Stack direction="row" spacing={1.5} alignItems="center">
+                <Videocam color="disabled" />
+                <Box>
+                  <Typography variant="subtitle2">Video {index + 1}</Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    Video upload is not available yet.
+                  </Typography>
+                </Box>
+              </Stack>
+              <IconButton
+                aria-label={`Remove video ${index + 1}`}
+                color="error"
+                size="small"
+                onClick={() => setVideoDrafts(current => current.filter(item => item.id !== draft.id))}
+              >
+                <Delete fontSize="small" />
+              </IconButton>
+            </Stack>
+          </Paper>
+        ))}
+
+        {feedbackDrafts.map((draft, index) => (
+          <Paper key={draft.id} variant="outlined" sx={{ p: 2 }}>
+            <Stack spacing={2}>
+              <Stack direction="row" justifyContent="space-between" alignItems="center">
+                <Typography variant="subtitle2">Feedback {index + 1}</Typography>
+                <IconButton
+                  aria-label={`Remove feedback ${index + 1}`}
+                  color="error"
+                  size="small"
+                  onClick={() => setFeedbackDrafts(current => current.filter(item => item.id !== draft.id))}
+                >
+                  <Delete fontSize="small" />
+                </IconButton>
+              </Stack>
+              <Stack direction={{ xs: "column", sm: "row" }} spacing={2} alignItems={{ sm: "center" }}>
+                <FormControl sx={{ minWidth: { xs: "100%", sm: 220 } }}>
+                  <InputLabel id="community-feedback-type-label">Feedback type</InputLabel>
+                  <Select
+                    labelId="community-feedback-type-label"
+                    label="Feedback type"
+                    value={draft.feedbackType}
+                    onChange={event =>
+                      setFeedbackDrafts(current =>
+                        current.map(item =>
+                          item.id === draft.id ? { ...item, feedbackType: event.target.value as FeedbackType } : item,
+                        ),
+                      )
+                    }
+                  >
+                    {Object.entries(feedbackLabels).map(([value, label]) => (
+                      <MenuItem
+                        key={value}
+                        value={value}
+                        disabled={feedbackDrafts.some(item => item.id !== draft.id && item.feedbackType === value)}
+                      >
+                        {label}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+                <Rating
+                  value={draft.rating}
+                  onChange={(_, value) =>
+                    setFeedbackDrafts(current =>
+                      current.map(item => item.id === draft.id ? { ...item, rating: value } : item),
+                    )
+                  }
+                />
+              </Stack>
+              <TextField
+                fullWidth
+                multiline
+                minRows={3}
+                label={`${feedbackLabels[draft.feedbackType]} feedback`}
+                value={draft.content}
+                onChange={event =>
+                  setFeedbackDrafts(current =>
+                    current.map(item => item.id === draft.id ? { ...item, content: event.target.value } : item),
+                  )
+                }
+              />
+            </Stack>
+          </Paper>
+        ))}
+
+        <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2}>
+          <Stack direction="row" spacing={0.5} alignItems="center">
+            <Tooltip title="Add image">
+              <span>
+                <IconButton
+                  component="label"
+                  color="primary"
+                  disabled={Boolean(disabledReason) || uploading || imageDrafts.length >= MAX_DRAFTS_PER_KIND}
+                  aria-label="Add image"
+                >
+                  {uploading ? <CircularProgress size={22} /> : <AddPhotoAlternate />}
+                  <input type="file" hidden accept="image/*" onChange={handleImageSelect} />
+                </IconButton>
+              </span>
+            </Tooltip>
+            <Tooltip title="Add video">
+              <span>
+                <IconButton
+                  color="primary"
+                  disabled={Boolean(disabledReason) || videoDrafts.length >= MAX_DRAFTS_PER_KIND}
+                  aria-label="Add video"
+                  onClick={addVideoDraft}
+                >
+                  <Videocam />
+                </IconButton>
+              </span>
+            </Tooltip>
+            <Tooltip title="Add feedback">
+              <span>
+                <IconButton
+                  color="primary"
+                  disabled={Boolean(disabledReason) || feedbackDrafts.length >= feedbackTypes.length}
+                  aria-label="Add feedback"
+                  onClick={addFeedbackDraft}
+                >
+                  <RateReview />
+                </IconButton>
+              </span>
+            </Tooltip>
+            <Typography variant="caption" color="text.secondary" sx={{ ml: 1 }}>
+              {draftCount} ready
+            </Typography>
+          </Stack>
+          <Button
+            variant="contained"
+            startIcon={loading ? <CircularProgress size={18} color="inherit" /> : <Send />}
+            disabled={submitDisabled}
+            onClick={() => void handleSubmit()}
+          >
+            Post
+          </Button>
+        </Stack>
+      </Stack>
+    </Box>
+  );
+}

--- a/src/components/events/community/CommunityPostCard.tsx
+++ b/src/components/events/community/CommunityPostCard.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import {
+  Avatar,
+  Box,
+  Button,
+  IconButton,
+  Link as MuiLink,
+  Paper,
+  Rating,
+  Stack,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import { Celebration, Delete, Favorite, Lightbulb, Link as LinkIcon, ThumbUp } from "@mui/icons-material";
+import Image from "next/image";
+import NextLink from "next/link";
+import type { ReactNode } from "react";
+import type { CommunityPostView, CommunityReactionKey } from "./types";
+
+const reactionConfig: Array<{
+  key: CommunityReactionKey;
+  label: string;
+  icon: ReactNode;
+}> = [
+  { key: "LIKE", label: "Like", icon: <ThumbUp fontSize="small" /> },
+  { key: "LOVE", label: "Love", icon: <Favorite fontSize="small" /> },
+  { key: "CELEBRATE", label: "Celebrate", icon: <Celebration fontSize="small" /> },
+  { key: "HELPFUL", label: "Helpful", icon: <Lightbulb fontSize="small" /> },
+];
+
+const feedbackLabels: Record<NonNullable<CommunityPostView["feedbackType"]>, string> = {
+  VENUE: "Venue",
+  ORGANIZATION: "Organization",
+  EVENTS: "Events",
+  OVERALL_EXPERIENCE: "Overall experience",
+};
+
+function initials(name: string) {
+  return name
+    .split(" ")
+    .filter(Boolean)
+    .map(part => part[0])
+    .slice(0, 2)
+    .join("")
+    .toUpperCase();
+}
+
+interface CommunityPostCardProps {
+  post: CommunityPostView;
+  canDelete: boolean;
+  deleteDisabled?: boolean;
+  reactionDisabled?: boolean;
+  onDelete: (postId: string) => void;
+  onReact: (postId: string, reaction: CommunityReactionKey) => void;
+}
+
+export default function CommunityPostCard({
+  post,
+  canDelete,
+  deleteDisabled,
+  reactionDisabled,
+  onDelete,
+  onReact,
+}: CommunityPostCardProps) {
+  const createdAt = new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(post.createdAt));
+  const showMainContent = Boolean(post.content && !(post.type === "FEEDBACK" && post.feedbacks.length > 0));
+
+  return (
+    <Paper variant="outlined" sx={{ p: 2.5, borderRadius: 2 }}>
+      <Stack spacing={2}>
+        <Stack direction="row" spacing={1.5} alignItems="center">
+          <NextLink href={`/profile/${post.author.id}`} style={{ textDecoration: "none" }}>
+            <Avatar
+              src={post.author.imageUrl || undefined}
+              alt={post.author.name}
+              sx={{ cursor: "pointer", "&:hover": { opacity: 0.8 } }}
+            >
+              {post.author.imageUrl ? null : initials(post.author.name) || "?"}
+            </Avatar>
+          </NextLink>
+          <Box sx={{ minWidth: 0, flex: 1 }}>
+            <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+              <MuiLink
+                component={NextLink}
+                href={`/profile/${post.author.id}`}
+                underline="hover"
+                color="text.primary"
+              >
+                <Typography variant="subtitle2" fontWeight={700}>
+                  {post.author.name}
+                </Typography>
+              </MuiLink>
+            </Stack>
+            <Typography variant="caption" color="text.secondary">
+              {createdAt}
+            </Typography>
+          </Box>
+          {canDelete ? (
+            <Tooltip title="Delete post">
+              <span>
+                <IconButton
+                  aria-label="Delete post"
+                  size="small"
+                  color="error"
+                  disabled={deleteDisabled}
+                  onClick={() => onDelete(post.id)}
+                >
+                  <Delete fontSize="small" />
+                </IconButton>
+              </span>
+            </Tooltip>
+          ) : null}
+        </Stack>
+
+        {post.feedbacks.length > 0 ? (
+          <Stack spacing={1.5}>
+            {post.feedbacks.map((feedback, index) => (
+              <Box key={`${feedback.feedbackType}-${index}`}>
+                <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 0.5 }}>
+                  {feedbackLabels[feedback.feedbackType]}
+                </Typography>
+                {feedback.rating ? <Rating value={feedback.rating} readOnly size="small" /> : null}
+                {feedback.content ? (
+                  <Typography variant="body2" sx={{ mt: feedback.rating ? 0.5 : 0, whiteSpace: "pre-wrap", overflowWrap: "anywhere" }}>
+                    {feedback.content}
+                  </Typography>
+                ) : null}
+              </Box>
+            ))}
+          </Stack>
+        ) : post.feedbackRating ? (
+          <Box>
+            {post.feedbackType ? (
+              <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 0.5 }}>
+                {feedbackLabels[post.feedbackType]}
+              </Typography>
+            ) : null}
+            <Rating value={post.feedbackRating} readOnly size="small" />
+          </Box>
+        ) : null}
+
+        {showMainContent ? (
+          <Typography variant="body1" sx={{ whiteSpace: "pre-wrap", overflowWrap: "anywhere" }}>
+            {post.content}
+          </Typography>
+        ) : null}
+
+        {post.linkUrl ? (
+          <Button
+            variant="outlined"
+            startIcon={<LinkIcon />}
+            component={MuiLink}
+            href={post.linkUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            sx={{ alignSelf: "flex-start", textTransform: "none", maxWidth: "100%" }}
+          >
+            <Typography component="span" noWrap>
+              {post.linkUrl}
+            </Typography>
+          </Button>
+        ) : null}
+
+        {post.imageUrls.length > 0 ? (
+          <Box
+            sx={{
+              display: "grid",
+              gridTemplateColumns: { xs: "1fr", sm: post.imageUrls.length > 1 ? "1fr 1fr" : "1fr" },
+              gap: 1,
+            }}
+          >
+            {post.imageUrls.map(url => (
+              <Box
+                key={url}
+                sx={{
+                  position: "relative",
+                  width: "100%",
+                  aspectRatio: "4 / 3",
+                  overflow: "hidden",
+                  borderRadius: 2,
+                  bgcolor: "grey.100",
+                }}
+              >
+                <Image src={url} alt="" fill sizes="(min-width: 900px) 420px, 100vw" style={{ objectFit: "cover" }} />
+              </Box>
+            ))}
+          </Box>
+        ) : null}
+
+        <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+          {reactionConfig.map(reaction => {
+            const active = post.viewerReactions.includes(reaction.key);
+            return (
+              <Tooltip title={reaction.label} key={reaction.key}>
+                <span>
+                  <Button
+                    size="small"
+                    variant={active ? "contained" : "outlined"}
+                    startIcon={reaction.icon}
+                    disabled={reactionDisabled}
+                    onClick={() => onReact(post.id, reaction.key)}
+                  >
+                    {post.reactions[reaction.key]}
+                  </Button>
+                </span>
+              </Tooltip>
+            );
+          })}
+        </Stack>
+      </Stack>
+    </Paper>
+  );
+}

--- a/src/components/events/community/CommunitySection.tsx
+++ b/src/components/events/community/CommunitySection.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Alert, Box, Button, CircularProgress, Divider, Paper, Stack, Typography } from "@mui/material";
+import CommunityComposer from "./CommunityComposer";
+import CommunityPostCard from "./CommunityPostCard";
+import type { CommunityPostView, CommunityReactionKey } from "./types";
+
+function getErrorMessage(raw: unknown, fallback: string) {
+  if (!raw || typeof raw !== "object") {
+    return fallback;
+  }
+
+  const payload = raw as {
+    error?: string | Array<{ message?: string }>;
+  };
+
+  if (typeof payload.error === "string") {
+    return payload.error;
+  }
+
+  if (Array.isArray(payload.error)) {
+    return payload.error[0]?.message || fallback;
+  }
+
+  return fallback;
+}
+
+interface CommunitySectionProps {
+  eventId: number;
+  eventEnded: boolean;
+  communityOpenAfterEnd: boolean;
+  currentUserId?: string | null;
+  canModerate?: boolean;
+}
+
+export default function CommunitySection({
+  eventId,
+  eventEnded,
+  communityOpenAfterEnd,
+  currentUserId,
+  canModerate,
+}: CommunitySectionProps) {
+  const [posts, setPosts] = useState<CommunityPostView[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [actionPostId, setActionPostId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const composerDisabledReason = useMemo(() => {
+    if (!currentUserId) {
+      return "Sign in to post or react in this community.";
+    }
+
+    if (eventEnded && !communityOpenAfterEnd) {
+      return "This community is read-only because the event has ended.";
+    }
+
+    return null;
+  }, [communityOpenAfterEnd, currentUserId, eventEnded]);
+
+  const loadPosts = async (cursor?: string | null) => {
+    cursor ? setLoadingMore(true) : setLoading(true);
+    setError(null);
+
+    try {
+      const params = new URLSearchParams({
+        eventId: String(eventId),
+        limit: "10",
+      });
+      if (cursor) {
+        params.set("cursor", cursor);
+      }
+
+      const response = await fetch(`/api/community/posts?${params.toString()}`);
+      const payload = (await response.json().catch(() => null)) as {
+        posts?: CommunityPostView[];
+        nextCursor?: string | null;
+        error?: unknown;
+      } | null;
+
+      if (!response.ok || !payload?.posts) {
+        throw new Error(getErrorMessage(payload, "Failed to load community posts"));
+      }
+
+      const loadedPosts = payload.posts;
+      setPosts(current => cursor ? [...current, ...loadedPosts] : loadedPosts);
+      setNextCursor(payload.nextCursor || null);
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : "Failed to load community posts");
+    } finally {
+      cursor ? setLoadingMore(false) : setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void loadPosts();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [eventId]);
+
+  const handlePostCreated = (post: CommunityPostView, pending: boolean) => {
+    if (!pending) {
+      setPosts(current => [post, ...current]);
+    }
+  };
+
+  const handleReact = async (postId: string, reaction: CommunityReactionKey) => {
+    const snapshot = posts.find(p => p.id === postId);
+
+    setPosts(current =>
+      current.map(post => {
+        if (post.id !== postId) return post;
+        const hasReaction = post.viewerReactions.includes(reaction);
+        return {
+          ...post,
+          reactions: {
+            ...post.reactions,
+            [reaction]: post.reactions[reaction] + (hasReaction ? -1 : 1),
+          },
+          viewerReactions: hasReaction
+            ? post.viewerReactions.filter(r => r !== reaction)
+            : [...post.viewerReactions, reaction],
+        };
+      }),
+    );
+
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/community/posts/${postId}/react`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reaction }),
+      });
+      const payload = (await response.json().catch(() => null)) as {
+        reactions?: CommunityPostView["reactions"];
+        viewerReactions?: string[];
+        error?: unknown;
+      } | null;
+
+      if (!response.ok || !payload?.reactions || !payload.viewerReactions) {
+        throw new Error(getErrorMessage(payload, "Failed to update reaction"));
+      }
+
+      const reactions = payload.reactions;
+      const viewerReactions = payload.viewerReactions;
+      setPosts(current =>
+        current.map(post => (post.id === postId ? { ...post, reactions, viewerReactions } : post)),
+      );
+    } catch (reactionError) {
+      if (snapshot) {
+        setPosts(current => current.map(post => (post.id === postId ? snapshot : post)));
+      }
+      setError(reactionError instanceof Error ? reactionError.message : "Failed to update reaction");
+    }
+  };
+
+  const handleDelete = async (postId: string) => {
+    setActionPostId(postId);
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/community/posts/${postId}`, {
+        method: "DELETE",
+      });
+      const payload = (await response.json().catch(() => null)) as { deleted?: boolean; error?: unknown } | null;
+
+      if (!response.ok || !payload?.deleted) {
+        throw new Error(getErrorMessage(payload, "Failed to delete post"));
+      }
+
+      setPosts(current => current.filter(post => post.id !== postId));
+    } catch (deleteError) {
+      setError(deleteError instanceof Error ? deleteError.message : "Failed to delete post");
+    } finally {
+      setActionPostId(null);
+    }
+  };
+
+  return (
+    <Paper variant="outlined" sx={{ p: 3 }}>
+      <Stack spacing={3}>
+        <Box>
+          <Typography variant="h4" gutterBottom fontWeight="bold">
+            Community
+          </Typography>
+          {eventEnded ? (
+            <Alert severity="info" sx={{ mt: 2 }}>
+              This is the post-event community space for attendees and organizers.
+            </Alert>
+          ) : null}
+        </Box>
+
+        <CommunityComposer
+          eventId={eventId}
+          disabledReason={composerDisabledReason}
+          onPostCreated={handlePostCreated}
+        />
+
+        <Divider />
+
+        {error ? <Alert severity="error">{error}</Alert> : null}
+
+        {loading ? (
+          <Box sx={{ py: 4, textAlign: "center" }}>
+            <CircularProgress />
+          </Box>
+        ) : posts.length === 0 ? (
+          <Alert severity="info">No community posts yet.</Alert>
+        ) : (
+          <Stack spacing={2}>
+            {posts.map(post => (
+              <CommunityPostCard
+                key={post.id}
+                post={post}
+                canDelete={Boolean(canModerate || post.authorId === currentUserId)}
+                deleteDisabled={!currentUserId || actionPostId === post.id}
+                reactionDisabled={!currentUserId || Boolean(composerDisabledReason)}
+                onDelete={handleDelete}
+                onReact={handleReact}
+              />
+            ))}
+          </Stack>
+        )}
+
+        {nextCursor ? (
+          <Button
+            variant="outlined"
+            onClick={() => void loadPosts(nextCursor)}
+            disabled={loadingMore}
+            sx={{ alignSelf: "center" }}
+          >
+            {loadingMore ? <CircularProgress size={20} /> : "Load More"}
+          </Button>
+        ) : null}
+      </Stack>
+    </Paper>
+  );
+}

--- a/src/components/events/community/types.ts
+++ b/src/components/events/community/types.ts
@@ -1,0 +1,35 @@
+export type CommunityPostType = "TEXT" | "IMAGE" | "LINK" | "FEEDBACK" | "VIDEO";
+export type CommunityFeedbackType = "VENUE" | "ORGANIZATION" | "EVENTS" | "OVERALL_EXPERIENCE";
+
+export type CommunityFeedbackItem = {
+  content: string | null;
+  rating: number | null;
+  feedbackType: CommunityFeedbackType;
+};
+
+export type CommunityReactionKey = "LIKE" | "LOVE" | "CELEBRATE" | "HELPFUL";
+
+export type CommunityPostView = {
+  id: string;
+  eventId: number;
+  authorId: string;
+  type: CommunityPostType;
+  tags: string[];
+  content: string | null;
+  imageUrls: string[];
+  linkUrl: string | null;
+  feedbackRating: number | null;
+  feedbackType: CommunityFeedbackType | null;
+  feedbacks: CommunityFeedbackItem[];
+  status: "PENDING" | "APPROVED" | "REJECTED" | "DELETED";
+  pinned: boolean;
+  createdAt: string;
+  updatedAt: string;
+  author: {
+    id: string;
+    name: string;
+    imageUrl: string | null;
+  };
+  reactions: Record<CommunityReactionKey, number>;
+  viewerReactions: string[];
+};

--- a/src/generated/prisma.ts
+++ b/src/generated/prisma.ts
@@ -1,5 +1,9 @@
 export {
+  CommunityFeedbackType,
+  CommunityPostType,
+  ModerationAction,
   PaymentStatus,
+  PostStatus,
   Prisma,
   PrismaClient,
   RegistrationStatus,
@@ -7,9 +11,12 @@ export {
 } from "./prisma/client";
 
 export type {
+  CommunityPost,
   Event,
   Payment,
   PendingAccountLink,
+  PostModerationLog,
+  PostReaction,
   Product,
   Registration,
 } from "./prisma/client";

--- a/src/lib/community/server.ts
+++ b/src/lib/community/server.ts
@@ -1,0 +1,382 @@
+import type { Prisma } from "@/generated/prisma";
+import { CommunityFeedbackType, CommunityPostType, ModerationAction, PostStatus } from "@/generated/prisma";
+import { prisma } from "@/lib/prisma/prisma";
+
+export const COMMUNITY_REACTIONS = ["LIKE", "LOVE", "CELEBRATE", "HELPFUL"] as const;
+
+export type CommunityReaction = (typeof COMMUNITY_REACTIONS)[number];
+
+const ACTIVE_ATTENDEE_STATUSES = ["PENDING", "APPROVED", "CONFIRMED"] as const;
+
+type CommunityPostTagInput = {
+  type: typeof CommunityPostType[keyof typeof CommunityPostType];
+  imageUrls?: string[];
+  linkUrl?: string | null;
+  feedbacks?: CommunityFeedbackTagInput[];
+  feedbackRating?: number | null;
+  feedbackType?: typeof CommunityFeedbackType[keyof typeof CommunityFeedbackType] | null;
+};
+
+type CommunityFeedbackTagInput = {
+  content?: string | null;
+  feedbackRating?: number | null;
+  feedbackType: typeof CommunityFeedbackType[keyof typeof CommunityFeedbackType];
+};
+
+type SerializedCommunityFeedback = {
+  content: string | null;
+  rating: number | null;
+  feedbackType: typeof CommunityFeedbackType[keyof typeof CommunityFeedbackType];
+};
+
+export class CommunityError extends Error {
+  constructor(
+    public status: number,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+export const communityPostInclude = {
+  author: {
+    select: {
+      id: true,
+      name: true,
+      image: true,
+      profilePictures: {
+        orderBy: [
+          { isPrimary: "desc" as const },
+          { order: "asc" as const },
+          { createdAt: "desc" as const },
+        ],
+        take: 1,
+        select: {
+          signedUrl: true,
+          isPrimary: true,
+        },
+      },
+    },
+  },
+  reactions: {
+    select: {
+      userId: true,
+      reaction: true,
+    },
+  },
+} satisfies Prisma.CommunityPostInclude;
+
+export type CommunityPostWithInclude = Prisma.CommunityPostGetPayload<{
+  include: typeof communityPostInclude;
+}>;
+
+export type CommunityActor = {
+  id: string;
+  isAdmin: boolean;
+  adminId: string | null;
+};
+
+export type CommunityEventAccess = {
+  id: number;
+  ownerId: string | null;
+  endDate: Date;
+  communityEnabled: boolean;
+  communityOpenAfterEnd: boolean;
+  communityModerated: boolean;
+  communityAttendeesOnly: boolean;
+};
+
+function isCommunityFeedbackType(value: unknown): value is typeof CommunityFeedbackType[keyof typeof CommunityFeedbackType] {
+  return typeof value === "string" && value in CommunityFeedbackType;
+}
+
+function normalizeCommunityFeedbackEntries(
+  feedbackEntries: Prisma.JsonValue | null | undefined,
+  fallback: {
+    content?: string | null;
+    feedbackRating?: number | null;
+    feedbackType?: typeof CommunityFeedbackType[keyof typeof CommunityFeedbackType] | null;
+  } = {},
+): SerializedCommunityFeedback[] {
+  if (Array.isArray(feedbackEntries)) {
+    const parsedEntries = feedbackEntries
+      .map(entry => {
+        if (!entry || typeof entry !== "object") {
+          return null;
+        }
+
+        const candidate = entry as Record<string, unknown>;
+        const feedbackType = candidate.feedbackType;
+        if (!isCommunityFeedbackType(feedbackType)) {
+          return null;
+        }
+
+        const content = typeof candidate.content === "string" ? candidate.content : null;
+        const rating = typeof candidate.feedbackRating === "number" ? candidate.feedbackRating : null;
+
+        return {
+          content,
+          rating,
+          feedbackType,
+        };
+      })
+      .filter((entry): entry is SerializedCommunityFeedback => Boolean(entry));
+
+    if (parsedEntries.length > 0) {
+      return parsedEntries;
+    }
+  }
+
+  if (fallback.feedbackType) {
+    return [
+      {
+        content: fallback.content ?? null,
+        rating: fallback.feedbackRating ?? null,
+        feedbackType: fallback.feedbackType,
+      },
+    ];
+  }
+
+  return [];
+}
+
+export async function loadCommunityActor(userId: string): Promise<CommunityActor | null> {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      id: true,
+      isAdmin: true,
+      adminProfile: {
+        select: {
+          id: true,
+        },
+      },
+    },
+  });
+
+  if (!user) {
+    return null;
+  }
+
+  return {
+    id: user.id,
+    isAdmin: user.isAdmin,
+    adminId: user.adminProfile?.id || null,
+  };
+}
+
+export async function loadCommunityEvent(eventId: number): Promise<CommunityEventAccess | null> {
+  return prisma.event.findUnique({
+    where: { id: eventId },
+    select: {
+      id: true,
+      ownerId: true,
+      endDate: true,
+      communityEnabled: true,
+      communityOpenAfterEnd: true,
+      communityModerated: true,
+      communityAttendeesOnly: true,
+    },
+  });
+}
+
+export function assertCommunityEnabled(event: CommunityEventAccess | null): asserts event is CommunityEventAccess {
+  if (!event) {
+    throw new CommunityError(404, "Event not found");
+  }
+
+  if (!event.communityEnabled) {
+    throw new CommunityError(403, "Community is disabled for this event");
+  }
+}
+
+export function isEventOwner(actor: CommunityActor | null, event: Pick<CommunityEventAccess, "ownerId">) {
+  return Boolean(actor?.adminId && event.ownerId === actor.adminId);
+}
+
+export function canBypassAttendeeOnly(actor: CommunityActor | null, event: Pick<CommunityEventAccess, "ownerId">) {
+  return Boolean(actor?.isAdmin || isEventOwner(actor, event));
+}
+
+export function assertCommunityOpenForWrites(event: CommunityEventAccess) {
+  if (!event.communityOpenAfterEnd && event.endDate.getTime() < Date.now()) {
+    throw new CommunityError(403, "Community posting is closed for this event");
+  }
+}
+
+export async function assertCanWriteInCommunity(actor: CommunityActor, event: CommunityEventAccess) {
+  assertCommunityOpenForWrites(event);
+
+  if (!event.communityAttendeesOnly || canBypassAttendeeOnly(actor, event)) {
+    return;
+  }
+
+  const registration = await prisma.registration.findFirst({
+    where: {
+      eventId: event.id,
+      userId: actor.id,
+      status: { in: [...ACTIVE_ATTENDEE_STATUSES] },
+    },
+    select: { id: true },
+  });
+
+  if (!registration) {
+    throw new CommunityError(403, "Only attendees can post in this event community");
+  }
+}
+
+export function assertCanDeletePost(
+  actor: CommunityActor,
+  post: { authorId: string; event: Pick<CommunityEventAccess, "ownerId"> },
+) {
+  if (post.authorId === actor.id || actor.isAdmin || isEventOwner(actor, post.event)) {
+    return;
+  }
+
+  throw new CommunityError(403, "You cannot delete this post");
+}
+
+export function serializeCommunityPost(post: CommunityPostWithInclude, viewerUserId?: string | null) {
+  const feedbacks = normalizeCommunityFeedbackEntries(post.feedbackEntries, {
+    content: post.content,
+    feedbackRating: post.feedbackRating,
+    feedbackType: post.feedbackType,
+  });
+  const primaryFeedback = feedbacks.find(feedback => feedback.rating !== null) || feedbacks[0] || null;
+  const reactionCounts = COMMUNITY_REACTIONS.reduce<Record<CommunityReaction, number>>((counts, reaction) => {
+    counts[reaction] = 0;
+    return counts;
+  }, {} as Record<CommunityReaction, number>);
+  const viewerReactions: string[] = [];
+
+  for (const reaction of post.reactions) {
+    if (reaction.reaction in reactionCounts) {
+      reactionCounts[reaction.reaction as CommunityReaction] += 1;
+    }
+    if (viewerUserId && reaction.userId === viewerUserId) {
+      viewerReactions.push(reaction.reaction);
+    }
+  }
+
+  return {
+    id: post.id,
+    eventId: post.eventId,
+    authorId: post.authorId,
+    type: post.type,
+    tags: post.tags,
+    content: post.content,
+    imageUrls: post.imageUrls,
+    linkUrl: post.linkUrl,
+    feedbackRating: primaryFeedback?.rating ?? post.feedbackRating,
+    feedbackType: primaryFeedback?.feedbackType ?? post.feedbackType,
+    feedbacks,
+    status: post.status,
+    pinned: post.pinned,
+    createdAt: post.createdAt.toISOString(),
+    updatedAt: post.updatedAt.toISOString(),
+    author: {
+      id: post.author.id,
+      name: post.author.name || "Attendee",
+      imageUrl: post.author.profilePictures[0]?.signedUrl || post.author.image || null,
+    },
+    reactions: reactionCounts,
+    viewerReactions,
+  };
+}
+
+export function deriveCommunityPostTags(input: CommunityPostTagInput) {
+  const tags = new Set<string>([input.type.toLowerCase()]);
+
+  if (input.type === CommunityPostType.IMAGE || input.type === CommunityPostType.VIDEO) {
+    tags.add("media");
+  }
+
+  if (input.imageUrls && input.imageUrls.length > 0) {
+    tags.add("image");
+    tags.add("media");
+  }
+
+  if (input.linkUrl) {
+    tags.add("link");
+  }
+
+  const feedbacks = input.feedbacks || [];
+
+  if (input.type === CommunityPostType.FEEDBACK || feedbacks.length > 0 || input.feedbackRating !== null && input.feedbackRating !== undefined) {
+    tags.add("feedback");
+  }
+
+  for (const feedback of feedbacks) {
+    tags.add(`feedback:${feedback.feedbackType.toLowerCase().replaceAll("_", "-")}`);
+    if (feedback.feedbackRating !== null && feedback.feedbackRating !== undefined) {
+      tags.add("rating");
+    }
+  }
+
+  if (feedbacks.length === 0) {
+    if (input.feedbackType) {
+      tags.add(`feedback:${input.feedbackType.toLowerCase().replaceAll("_", "-")}`);
+    }
+
+    if (input.feedbackRating !== null && input.feedbackRating !== undefined) {
+      tags.add("rating");
+    }
+  }
+
+  return Array.from(tags).sort();
+}
+
+export async function writeModerationLog(input: {
+  postId: string;
+  actor: CommunityActor;
+  action: typeof ModerationAction[keyof typeof ModerationAction];
+  reason?: string;
+  metadata?: Prisma.InputJsonValue;
+}) {
+  await prisma.postModerationLog.create({
+    data: {
+      postId: input.postId,
+      actorUserId: input.actor.id,
+      actorAdminId: input.actor.adminId,
+      action: input.action,
+      reason: input.reason,
+      metadata: input.metadata || {},
+    },
+  });
+}
+
+export async function softDeletePost(input: {
+  postId: string;
+  actor: CommunityActor;
+}) {
+  await prisma.$transaction([
+    prisma.postReaction.deleteMany({
+      where: { postId: input.postId },
+    }),
+    prisma.communityPost.update({
+      where: { id: input.postId },
+      data: {
+        status: PostStatus.DELETED,
+        content: null,
+        tags: [],
+        imageUrls: [],
+        linkUrl: null,
+        feedbackRating: null,
+        feedbackType: null,
+        feedbackEntries: [],
+        muxAssetId: null,
+        muxPlaybackId: null,
+        deletedAt: new Date(),
+        moderationLogs: {
+          create: {
+            actorUserId: input.actor.id,
+            actorAdminId: input.actor.adminId,
+            action: ModerationAction.DELETED,
+            reason: "Deleted by authorized user",
+            metadata: {},
+          },
+        },
+      },
+    }),
+  ]);
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -44,6 +44,19 @@ export async function uploadEventImage(file: Buffer, fileName: string) {
     return data;
 }
 
+export async function uploadCommunityImage(file: Buffer, eventId: number, userId: string, fileName: string) {
+    const { data, error } = await getSupabaseClient().storage
+        .from(process.env.SUPABASE_BUCKET_ID)
+        .upload(`community/${eventId}/${userId}/${fileName}`, file, {
+            cacheControl: '3600',
+            upsert: false,
+            contentType: 'image/jpeg'
+    });
+
+    if(error) throw error;
+    return data;
+}
+
 
 export async function getSignedUrl(path: string, expiresIn: number = 300) {
     const { data, error } = await getSupabaseClient().storage

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -72,6 +72,10 @@ export interface SerializedEvent {
   imageUrl: string | null;
   status: 'DRAFT' | 'PUBLISHED' | 'CANCELLED';
   scanOnce?: boolean;
+  communityEnabled?: boolean;
+  communityOpenAfterEnd?: boolean;
+  communityModerated?: boolean;
+  communityAttendeesOnly?: boolean;
   stayPolicy: SerializedStayPolicy;
   schedule: SerializedScheduleItem[];
   location?: SerializedLocation | null;

--- a/src/types/schemas/community.ts
+++ b/src/types/schemas/community.ts
@@ -1,0 +1,106 @@
+import { z } from "zod";
+
+export const communityPostTypeSchema = z.enum(["TEXT", "IMAGE", "LINK", "FEEDBACK", "VIDEO"]);
+const communityReactionSchemaValues = ["LIKE", "LOVE", "CELEBRATE", "HELPFUL"] as const;
+export const communityFeedbackTypeSchema = z.enum(["VENUE", "ORGANIZATION", "EVENTS", "OVERALL_EXPERIENCE"]);
+
+export const communityFeedbackEntrySchema = z.object({
+  content: z.string().trim().max(5000).optional(),
+  feedbackRating: z.coerce.number().int().min(1).max(5).optional(),
+  feedbackType: communityFeedbackTypeSchema,
+});
+
+export const createCommunityPostSchema = z
+  .object({
+    eventId: z.coerce.number().int().positive(),
+    type: communityPostTypeSchema,
+    content: z.string().trim().max(5000).optional(),
+    imageUrls: z.array(z.url()).max(5).default([]),
+    linkUrl: z.url().optional(),
+    feedbackRating: z.coerce.number().int().min(1).max(5).optional(),
+    feedbackType: communityFeedbackTypeSchema.optional(),
+    feedbacks: z.array(communityFeedbackEntrySchema).max(5).default([]),
+  })
+  .superRefine((data, ctx) => {
+    if (data.type === "VIDEO") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["type"],
+        message: "Video posts are not supported yet",
+      });
+    }
+
+    if (data.type === "TEXT" && !data.content?.trim()) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["content"],
+        message: "Text posts need content",
+      });
+    }
+
+    if (data.type === "IMAGE" && data.imageUrls.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["imageUrls"],
+        message: "Image posts need at least one image",
+      });
+    }
+
+    if (data.type === "LINK" && !data.linkUrl) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["linkUrl"],
+        message: "Link posts need a URL",
+      });
+    }
+
+    if (data.feedbacks.some(feedback => !feedback.content?.trim() && feedback.feedbackRating === undefined)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["feedbacks"],
+        message: "Each feedback item needs a rating or message",
+      });
+    }
+
+    const feedbackTypes = new Set<string>();
+    for (const feedback of data.feedbacks) {
+      if (feedbackTypes.has(feedback.feedbackType)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["feedbacks"],
+          message: "Each feedback type can only be added once per post",
+        });
+        break;
+      }
+      feedbackTypes.add(feedback.feedbackType);
+    }
+
+    if (data.type === "FEEDBACK" && data.feedbacks.length === 0 && data.feedbackRating === undefined && !data.content?.trim()) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["feedbacks"],
+        message: "Feedback posts need a rating or message",
+      });
+    }
+
+    if (data.type === "FEEDBACK" && data.feedbacks.length === 0 && !data.feedbackType) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["feedbackType"],
+        message: "Feedback posts need a feedback type",
+      });
+    }
+  });
+
+export const listCommunityPostsSchema = z.object({
+  eventId: z.coerce.number().int().positive(),
+  cursor: z.string().min(1).optional(),
+  limit: z.coerce.number().int().min(1).max(50).default(20),
+});
+
+export const reactToCommunityPostSchema = z.object({
+  reaction: z.enum(communityReactionSchemaValues),
+});
+
+export type CreateCommunityPostInput = z.infer<typeof createCommunityPostSchema>;
+export type CommunityFeedbackInput = z.infer<typeof communityFeedbackEntrySchema>;

--- a/src/types/schemas/event/base.ts
+++ b/src/types/schemas/event/base.ts
@@ -240,6 +240,14 @@ export const EventBaseObject = z.object({
   requireApproval: z.boolean().default(false),
   /** Allow a ticket to be accepted only once at check-in */
   scanOnce: z.boolean().default(false),
+  /** Enable the event community feed */
+  communityEnabled: z.boolean().default(false),
+  /** Keep posting/reactions open after the event end date */
+  communityOpenAfterEnd: z.boolean().default(true),
+  /** New posts require moderation before they appear publicly */
+  communityModerated: z.boolean().default(true),
+  /** Restrict community writes to active attendees */
+  communityAttendeesOnly: z.boolean().default(true),
   /** Fixed deadline for all payments */
   paymentDeadline: z.coerce.date().nullable().optional(),
 


### PR DESCRIPTION
feat(community): add event community feed with posts, reactions, and moderation

- Schema: CommunityPost, PostReaction, PostModerationLog + 4 migrations (tags GIN index, typed feedback categories, grouped feedback entries)
- API: list/create posts, toggle reaction (optimistic on client, server reconcile), soft delete, image upload via sharp → Supabase
- UI: feed, post card with author avatar/name → /profile/:id (next/link to preserve router cache on back-nav), composer for text/image/feedback
- Admin EventForm: enable/moderate/attendees-only/open-after-end toggles
- Tests: auth, attendee-gate, moderation status, feedback tags, owner bypass

## Summary

## Testing

<!-- ventry:auto-fixes:start -->
Fixes #32
<!-- ventry:auto-fixes:end -->
