### PR TITLE
improve workflow 2026-06-18

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,13 +1,17 @@
 name: Add issues to project
+
 on:
   issues:
     types: [opened, labeled]
+
 permissions:
-  issues: write
-  repository-projects: write
+  issues: read
   contents: read
+
 jobs:
   add:
+    # New issues are always added. Already-open issues can be backfilled by adding this label.
+    if: github.event.action == 'opened' || github.event.label.name == 'add-to-project'
     runs-on: ubuntu-latest
     steps:
       - name: Create board management token
@@ -18,7 +22,8 @@ jobs:
           private-key: ${{ secrets.VENTRY_BOARD_APP_PRIVATE_KEY }}
           owner: Ventry-io
 
-      - uses: actions/add-to-project@v1.0.2
+      - name: Add issue to project
+        uses: actions/add-to-project@v2
         with:
           project-url: https://github.com/orgs/Ventry-io/projects/1
           github-token: ${{ steps.board-token.outputs.token }}

--- a/.github/workflows/create-main-release.yml
+++ b/.github/workflows/create-main-release.yml
@@ -52,6 +52,21 @@ jobs:
           script: |
             const marker = "<!-- ventry:release-controls -->";
             const pr = context.payload.pull_request;
+            const allowedAssociations = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+            const trustedBotLogins = new Set(
+              (process.env.TRUSTED_RELEASE_CONTROL_BOTS || "github-actions[bot]")
+                .split(",")
+                .map((login) => login.trim())
+                .filter(Boolean)
+            );
+
+            function isTrustedControlComment(comment) {
+              return comment.body?.includes(marker)
+                && (
+                  allowedAssociations.has(comment.author_association)
+                  || trustedBotLogins.has(comment.user?.login)
+                );
+            }
 
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
@@ -61,7 +76,7 @@ jobs:
             });
 
             const controlComments = comments
-              .filter((comment) => comment.body?.includes(marker))
+              .filter(isTrustedControlComment)
               .sort((left, right) => new Date(right.updated_at) - new Date(left.updated_at));
 
             function parseControlComment(body = "") {

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,27 +29,14 @@ jobs:
     permissions:
       contents: read
     concurrency:
-      group: deploy-${{ github.ref_name }}
+      group: deploy-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.target || github.ref_name }}
       cancel-in-progress: true
 
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref }}
-
-      - name: Resolve build metadata
-        id: build_metadata
-        run: |
-          tag="$(git describe --tags --abbrev=0 2>/dev/null || node -p "'v' + JSON.parse(require('fs').readFileSync('package.json', 'utf8')).version")"
-
-          echo "commit=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
-          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
-          echo "build_date=$(git show -s --format=%cI HEAD)" >> "$GITHUB_OUTPUT"
-
       - name: Resolve deployment target
         id: target
         env:
+          INPUT_TARGET: ${{ github.event.inputs.target }}
           DEV_BETTER_AUTH_URL: ${{ secrets.DEV_BETTER_AUTH_URL }}
           MAIN_BETTER_AUTH_URL: ${{ secrets.MAIN_BETTER_AUTH_URL }}
           DEV_NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: ${{ secrets.DEV_NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY }}
@@ -58,13 +45,14 @@ jobs:
           MAIN_DATABASE_URL: ${{ secrets.MAIN_DATABASE_URL }}
         run: |
           if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
-            DEPLOY_TARGET="${{ github.event.inputs.target }}"
+            DEPLOY_TARGET="${INPUT_TARGET}"
           else
             DEPLOY_TARGET="${GITHUB_REF_NAME}"
           fi
 
           case "${DEPLOY_TARGET}" in
             dev)
+              echo "branch=dev" >> "$GITHUB_OUTPUT"
               echo "tag=dev" >> "$GITHUB_OUTPUT"
               echo "compose_file=docker-compose.dev.yml" >> "$GITHUB_OUTPUT"
               echo "better_auth_url=${DEV_BETTER_AUTH_URL:-https://dev-ventry.m-loeffler.de}" >> "$GITHUB_OUTPUT"
@@ -73,6 +61,7 @@ jobs:
               echo "database_url=${DEV_DATABASE_URL}" >> "$GITHUB_OUTPUT"
               ;;
             main)
+              echo "branch=main" >> "$GITHUB_OUTPUT"
               echo "tag=main" >> "$GITHUB_OUTPUT"
               echo "compose_file=docker-compose.main.yml" >> "$GITHUB_OUTPUT"
               echo "better_auth_url=${MAIN_BETTER_AUTH_URL:-https://ventry.m-loeffler.de}" >> "$GITHUB_OUTPUT"
@@ -85,6 +74,20 @@ jobs:
               exit 1
               ;;
           esac
+
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.target.outputs.branch }}
+
+      - name: Resolve build metadata
+        id: build_metadata
+        run: |
+          tag="$(git describe --tags --abbrev=0 2>/dev/null || node -p "'v' + JSON.parse(require('fs').readFileSync('package.json', 'utf8')).version")"
+
+          echo "commit=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "build_date=$(git show -s --format=%cI HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/guard-main-target.yml
+++ b/.github/workflows/guard-main-target.yml
@@ -3,7 +3,6 @@ name: Guard main PR target
 on:
   pull_request_target:
     types: [opened, edited, reopened, synchronize, ready_for_review, labeled, unlabeled]
-    branches: [main]
 
 permissions:
   contents: read
@@ -17,10 +16,20 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const pr = context.payload.pull_request;
+            const payloadPr = context.payload.pull_request;
             const confirmationLabel = "confirmed-main-target";
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: payloadPr.number,
+            });
+
             const labels = pr.labels.map((label) => label.name);
-            const isReleasePr = pr.head.ref === "dev" && pr.head.repo.full_name === context.payload.repository.full_name;
+            const isMainTarget = pr.base.ref === "main";
+            const isReleasePr =
+              pr.head.ref === "dev" &&
+              pr.head.repo.full_name === context.payload.repository.full_name;
             const isConfirmed = labels.includes(confirmationLabel);
 
             const summary = [
@@ -33,6 +42,14 @@ jobs:
               "",
             ];
 
+            if (!isMainTarget) {
+              summary.push(
+                "This PR does not target `main`, so the main-target guard passes."
+              );
+              await core.summary.addRaw(summary.join("\n")).write();
+              return;
+            }
+
             if (isReleasePr) {
               summary.push("This is the expected release PR from `dev` to `main`.");
               await core.summary.addRaw(summary.join("\n")).write();
@@ -44,7 +61,9 @@ jobs:
                 "This PR does not come from `dev`, but a maintainer confirmed the `main` target with the label."
               );
               await core.summary.addRaw(summary.join("\n")).write();
-              core.warning(`PR targets main from '${pr.head.ref}'. Confirmation label '${confirmationLabel}' is present.`);
+              core.warning(
+                `PR targets main from '${pr.head.ref}'. Confirmation label '${confirmationLabel}' is present.`
+              );
               return;
             }
 
@@ -53,7 +72,9 @@ jobs:
               "",
               "Normal feature branches should target `dev`. If this PR intentionally targets `main`, add the maintainer confirmation label before merging."
             );
+
             await core.summary.addRaw(summary.join("\n")).write();
+
             core.setFailed(
               `PRs targeting main must come from dev, or carry the '${confirmationLabel}' label.`
             );

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 25
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/update-main-pr-description.yml
+++ b/.github/workflows/update-main-pr-description.yml
@@ -68,6 +68,21 @@ jobs:
             const marker = "<!-- ventry:release-controls -->";
             const prNumber = Number("${{ steps.pr-context.outputs.pr_number }}");
             const calculatedVersion = process.env.CALCULATED_VERSION;
+            const allowedAssociations = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+            const trustedBotLogins = new Set(
+              (process.env.TRUSTED_RELEASE_CONTROL_BOTS || "github-actions[bot]")
+                .split(",")
+                .map((login) => login.trim())
+                .filter(Boolean)
+            );
+
+            function isTrustedControlComment(comment) {
+              return comment.body?.includes(marker)
+                && (
+                  allowedAssociations.has(comment.author_association)
+                  || trustedBotLogins.has(comment.user?.login)
+                );
+            }
 
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
@@ -77,7 +92,7 @@ jobs:
             });
 
             const controlComments = comments
-              .filter((comment) => comment.body?.includes(marker))
+              .filter(isTrustedControlComment)
               .sort((left, right) => new Date(right.updated_at) - new Date(left.updated_at));
 
             function parseControlComment(body = "") {
@@ -111,7 +126,7 @@ jobs:
             ].join("\n");
 
             const botComment = comments.find((comment) =>
-              comment.user?.type === "Bot" && comment.body?.includes(marker)
+              trustedBotLogins.has(comment.user?.login) && comment.body?.includes(marker)
             );
 
             if (botComment) {


### PR DESCRIPTION
fix: deploy.yml — real bug fixes:
- Checkout moved after target resolution so ref: uses steps.target.outputs.branch (correct deployed branch, not triggering ref)
- commit was ${GITHUB_SHA::7} (triggering SHA) → git rev-parse --short HEAD (actual deployed commit)
- Concurrency group fixed for workflow_dispatch — was always github.ref_name which is wrong on manual trigger
- INPUT_TARGET env var instead of inline expression in run: — closes shell injection vector

create-main-release.yml + update-main-pr-description.yml — security fix:
- Release control comments now filtered through isTrustedControlComment — only OWNER/MEMBER/COLLABORATOR or configured bot logins. Previously any user posting the marker string could influence release controls.

guard-main-target.yml:
- Removed branches: [main] filter so the check always runs and reports on all PRs — required for required status checks to work on non-main targets too
- Fetches fresh PR data via API (payload can be stale on synchronize)
- Early return path for non-main targets is clean

pr-tests.yml — Node 25 → 24. Node 25 is odd/experimental; 24 is current LTS.

add-to-project.yml — permission tightened (issues: read only, board write via app token), bumped to add-to-project@v2.

## Summary

## Testing

