### PR TITLE
37 feat(community): add moderation and admin controls (#37)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "certs:local:ca": "bash scripts/generate-local-certs.sh --ca",
     "db:backup": "bash scripts/db-backup.sh",
     "db:restore": "bash scripts/db-restore.sh",
-    "db:reset": "bash scripts/db-reset.sh"
+    "db:reset": "bash scripts/db-reset.sh",
+    "db:migrate": "./scripts/prisma-migrate-dev.mjs"
   },
   "dependencies": {
     "@better-auth/passkey": "^1.6.9",

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,4 +1,5 @@
-import { defineConfig, env } from "prisma/config";
+import { defineConfig } from "prisma/config";
+import "dotenv/config";
 
 export default defineConfig({
   schema: "prisma/schema.prisma",
@@ -7,6 +8,6 @@ export default defineConfig({
     seed: "tsx prisma/seed.ts",
   },
   datasource: {
-    url: env("DATABASE_URL"),
+    url: process.env["DATABASE_URL"],
   },
 });

--- a/prisma/migrations/20260618005416_add_pinned_unpinned_moderation_actions/migration.sql
+++ b/prisma/migrations/20260618005416_add_pinned_unpinned_moderation_actions/migration.sql
@@ -1,0 +1,13 @@
+-- AlterEnum
+-- This migration adds more than one value to an enum.
+-- With PostgreSQL versions 11 and earlier, this is not possible
+-- in a single migration. This can be worked around by creating
+-- multiple migrations, each migration adding only one value to
+-- the enum.
+
+
+ALTER TYPE "ModerationAction" ADD VALUE 'PINNED';
+ALTER TYPE "ModerationAction" ADD VALUE 'UNPINNED';
+
+-- DropIndex
+DROP INDEX "CommunityPost_tags_idx";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -505,4 +505,6 @@ enum ModerationAction {
   APPROVED
   REJECTED
   DELETED
+  PINNED
+  UNPINNED
 }

--- a/scripts/prisma-migrate-dev.mjs
+++ b/scripts/prisma-migrate-dev.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import dotenv from "dotenv";
+
+const envFile = resolve(process.cwd(), ".env");
+
+if (!existsSync(envFile)) {
+  console.error("❌ No .env file found in the current directory.");
+  process.exit(1);
+}
+
+const result = dotenv.config({ path: envFile });
+
+if (result.error) {
+  console.error("❌ Could not load .env file:");
+  console.error(result.error);
+  process.exit(1);
+}
+
+if (!process.env.DATABASE_URL) {
+  console.error("❌ DATABASE_URL is not set in the .env file.");
+  process.exit(1);
+}
+
+const args = ["prisma", "migrate", "dev", ...process.argv.slice(2)];
+
+const child = spawn("npx", args, {
+  stdio: "inherit",
+  shell: process.platform === "win32",
+  env: {
+    ...process.env,
+    DATABASE_URL: process.env.DATABASE_URL,
+  },
+});
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    console.error(`❌ Process was terminated by signal: ${signal}`);
+    process.exit(1);
+  }
+
+  process.exit(code ?? 0);
+});

--- a/src/app/admin/events/[id]/community/page.tsx
+++ b/src/app/admin/events/[id]/community/page.tsx
@@ -1,0 +1,53 @@
+import { Suspense } from "react";
+import { notFound, redirect } from "next/navigation";
+import { Box } from "@mui/material";
+import { checkEventAdminAuth } from "@/lib/auth/event-admin";
+import { prisma } from "@/lib/prisma/prisma";
+import PageLoadingState from "@/components/common/PageLoadingState";
+import CommunityModerationPanel from "@/components/admin/community/CommunityModerationPanel";
+
+export default function AdminEventCommunityPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  return (
+    <Suspense fallback={<PageLoadingState />}>
+      <AdminEventCommunityPageContent params={params} />
+    </Suspense>
+  );
+}
+
+async function AdminEventCommunityPageContent({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const eventId = Number((await params).id);
+  if (Number.isNaN(eventId)) notFound();
+
+  const auth = await checkEventAdminAuth(eventId);
+  if (!auth.authorized) {
+    redirect(`/login?callbackUrl=/admin/events/${eventId}/community`);
+  }
+
+  const event = await prisma.event.findUnique({
+    where: { id: eventId },
+    select: { id: true, communityEnabled: true, communityModerated: true },
+  });
+
+  if (!event) notFound();
+
+  if (!event.communityEnabled) {
+    redirect(`/admin/events/${eventId}`);
+  }
+
+  return (
+    <Box sx={{ py: 4 }}>
+      <CommunityModerationPanel
+        eventId={event.id}
+        communityModerated={event.communityModerated}
+      />
+    </Box>
+  );
+}

--- a/src/app/api/admin/event/[id]/community/logs/route.test.ts
+++ b/src/app/api/admin/event/[id]/community/logs/route.test.ts
@@ -1,0 +1,218 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const prismaMock = vi.hoisted(() => ({
+  postModerationLog: {
+    findMany: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/prisma/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+vi.mock("@/lib/auth/event-admin", () => ({
+  checkEventAdminAuth: vi.fn(),
+}));
+
+import * as logsRoute from "./route";
+import { checkEventAdminAuth } from "@/lib/auth/event-admin";
+
+const mockedCheckEventAdminAuth = checkEventAdminAuth as unknown as ReturnType<typeof vi.fn>;
+const mockedFindMany = prismaMock.postModerationLog.findMany as unknown as ReturnType<typeof vi.fn>;
+
+function getRequest(eventId: string, query: Record<string, string> = {}) {
+  const url = new URL(`http://localhost/api/admin/event/${eventId}/community/logs`);
+  for (const [k, v] of Object.entries(query)) {
+    url.searchParams.set(k, v);
+  }
+  return new NextRequest(url.toString());
+}
+
+function authorizedAdmin() {
+  return {
+    authorized: true,
+    adminId: "admin-1",
+    user: { id: "user-admin", email: "admin@example.com" },
+  };
+}
+
+function makeLog(id: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    postId: `post-for-${id}`,
+    action: "APPROVED",
+    reason: null,
+    createdAt: new Date("2026-06-18T12:00:00.000Z"),
+    post: { id: `post-for-${id}`, type: "TEXT", content: "hello", status: "APPROVED" },
+    actorUser: { id: "user-admin", name: "Admin User", email: "admin@example.com" },
+    ...overrides,
+  };
+}
+
+describe("GET /api/admin/event/[id]/community/logs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedCheckEventAdminAuth.mockResolvedValue(authorizedAdmin());
+    mockedFindMany.mockResolvedValue([makeLog("log-1"), makeLog("log-2")]);
+  });
+
+  it("returns 400 for non-numeric event ID", async () => {
+    const response = await logsRoute.GET(
+      getRequest("not-a-number"),
+      { params: Promise.resolve({ id: "not-a-number" }) },
+    );
+
+    expect(response.status).toBe(400);
+    const body = await response.json() as { error: string };
+    expect(body.error).toBe("Invalid event ID");
+    expect(mockedCheckEventAdminAuth).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when caller is not event admin", async () => {
+    mockedCheckEventAdminAuth.mockResolvedValue({ authorized: false, error: "Forbidden" });
+
+    const response = await logsRoute.GET(
+      getRequest("7"),
+      { params: Promise.resolve({ id: "7" }) },
+    );
+
+    expect(response.status).toBe(403);
+    expect(mockedFindMany).not.toHaveBeenCalled();
+  });
+
+  it("returns log list with actor info and no nextCursor when under limit", async () => {
+    mockedFindMany.mockResolvedValue([makeLog("log-1"), makeLog("log-2")]);
+
+    const response = await logsRoute.GET(
+      getRequest("7"),
+      { params: Promise.resolve({ id: "7" }) },
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as {
+      logs: Array<{ id: string; actor: { id: string; name: string; email: string } | null }>;
+      nextCursor: unknown;
+    };
+    expect(body.logs).toHaveLength(2);
+    expect(body.nextCursor).toBeNull();
+
+    const first = body.logs[0];
+    expect(first?.id).toBe("log-1");
+    expect(first?.actor).toEqual({
+      id: "user-admin",
+      name: "Admin User",
+      email: "admin@example.com",
+    });
+  });
+
+  it("serializes createdAt as ISO string", async () => {
+    mockedFindMany.mockResolvedValue([makeLog("log-1")]);
+
+    const response = await logsRoute.GET(
+      getRequest("7"),
+      { params: Promise.resolve({ id: "7" }) },
+    );
+
+    const body = await response.json() as { logs: Array<{ createdAt: string }> };
+    expect(body.logs[0]?.createdAt).toBe("2026-06-18T12:00:00.000Z");
+  });
+
+  it("sets actor to null when no actorUser linked", async () => {
+    mockedFindMany.mockResolvedValue([makeLog("log-1", { actorUser: null })]);
+
+    const response = await logsRoute.GET(
+      getRequest("7"),
+      { params: Promise.resolve({ id: "7" }) },
+    );
+
+    const body = await response.json() as { logs: Array<{ actor: unknown }> };
+    expect(body.logs[0]?.actor).toBeNull();
+  });
+
+  it("paginates: returns nextCursor when more logs exist", async () => {
+    mockedFindMany.mockResolvedValue(
+      Array.from({ length: 51 }, (_, i) => makeLog(`log-${i}`)),
+    );
+
+    const response = await logsRoute.GET(
+      getRequest("7", { limit: "50" }),
+      { params: Promise.resolve({ id: "7" }) },
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as { logs: unknown[]; nextCursor: string };
+    expect(body.logs).toHaveLength(50);
+    expect(body.nextCursor).toBe("log-49");
+  });
+
+  it("passes cursor to findMany when cursor param provided", async () => {
+    await logsRoute.GET(
+      getRequest("7", { cursor: "log-50" }),
+      { params: Promise.resolve({ id: "7" }) },
+    );
+
+    expect(mockedFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cursor: { id: "log-50" },
+        skip: 1,
+      }),
+    );
+  });
+
+  it("clamps limit to 100 even if caller requests more", async () => {
+    mockedFindMany.mockResolvedValue([makeLog("log-1")]);
+
+    await logsRoute.GET(
+      getRequest("7", { limit: "999" }),
+      { params: Promise.resolve({ id: "7" }) },
+    );
+
+    expect(mockedFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        take: 101,
+      }),
+    );
+  });
+
+  it("defaults limit to 50 for NaN limit param", async () => {
+    mockedFindMany.mockResolvedValue([makeLog("log-1")]);
+
+    await logsRoute.GET(
+      getRequest("7", { limit: "abc" }),
+      { params: Promise.resolve({ id: "7" }) },
+    );
+
+    expect(mockedFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        take: 51,
+      }),
+    );
+  });
+
+  it("scopes query to eventId via post.eventId", async () => {
+    await logsRoute.GET(
+      getRequest("42"),
+      { params: Promise.resolve({ id: "42" }) },
+    );
+
+    expect(mockedFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { post: { eventId: 42 } },
+      }),
+    );
+  });
+
+  it("orders logs by createdAt descending", async () => {
+    await logsRoute.GET(
+      getRequest("7"),
+      { params: Promise.resolve({ id: "7" }) },
+    );
+
+    expect(mockedFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: { createdAt: "desc" },
+      }),
+    );
+  });
+});

--- a/src/app/api/admin/event/[id]/community/logs/route.ts
+++ b/src/app/api/admin/event/[id]/community/logs/route.ts
@@ -1,0 +1,51 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { checkEventAdminAuth } from "@/lib/auth/event-admin";
+import { prisma } from "@/lib/prisma/prisma";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const eventId = Number((await params).id);
+  if (Number.isNaN(eventId)) {
+    return NextResponse.json({ error: "Invalid event ID" }, { status: 400 });
+  }
+
+  const auth = await checkEventAdminAuth(eventId, req.headers);
+  if (!auth.authorized) {
+    return NextResponse.json({ error: auth.error }, { status: 403 });
+  }
+
+  const url = new URL(req.url);
+  const cursor = url.searchParams.get("cursor") || undefined;
+  const limit = Math.min(Number(url.searchParams.get("limit") || "50") || 50, 100);
+
+  const logs = await prisma.postModerationLog.findMany({
+    where: { post: { eventId } },
+    include: {
+      post: { select: { id: true, type: true, content: true, status: true } },
+      actorUser: { select: { id: true, name: true, email: true } },
+    },
+    orderBy: { createdAt: "desc" },
+    take: limit + 1,
+    ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+  });
+
+  const hasMore = logs.length > limit;
+  const page = hasMore ? logs.slice(0, limit) : logs;
+
+  return NextResponse.json({
+    logs: page.map(log => ({
+      id: log.id,
+      postId: log.postId,
+      action: log.action,
+      reason: log.reason,
+      createdAt: log.createdAt.toISOString(),
+      post: log.post,
+      actor: log.actorUser
+        ? { id: log.actorUser.id, name: log.actorUser.name, email: log.actorUser.email }
+        : null,
+    })),
+    nextCursor: hasMore ? (page[page.length - 1]?.id ?? null) : null,
+  });
+}

--- a/src/app/api/admin/event/[id]/community/posts/route.test.ts
+++ b/src/app/api/admin/event/[id]/community/posts/route.test.ts
@@ -1,0 +1,207 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const prismaMock = vi.hoisted(() => ({
+  communityPost: {
+    findMany: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/prisma/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+vi.mock("@/lib/auth/event-admin", () => ({
+  checkEventAdminAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/community/server", () => ({
+  communityPostInclude: {},
+  serializeCommunityPost: vi.fn((p: { id: string }) => ({ id: p.id, serialized: true })),
+}));
+
+import * as postsRoute from "./route";
+import { checkEventAdminAuth } from "@/lib/auth/event-admin";
+
+const mockedCheckEventAdminAuth = checkEventAdminAuth as unknown as ReturnType<typeof vi.fn>;
+const mockedFindMany = prismaMock.communityPost.findMany as unknown as ReturnType<typeof vi.fn>;
+
+function getRequest(eventId: string, query: Record<string, string> = {}) {
+  const url = new URL(`http://localhost/api/admin/event/${eventId}/community/posts`);
+  for (const [k, v] of Object.entries(query)) {
+    url.searchParams.set(k, v);
+  }
+  return new NextRequest(url.toString());
+}
+
+function authorizedAdmin() {
+  return {
+    authorized: true,
+    adminId: "admin-1",
+    user: { id: "user-admin", email: "admin@example.com" },
+  };
+}
+
+function makePosts(count: number) {
+  return Array.from({ length: count }, (_, i) => ({ id: `post-${i}` }));
+}
+
+describe("GET /api/admin/event/[id]/community/posts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedCheckEventAdminAuth.mockResolvedValue(authorizedAdmin());
+    mockedFindMany.mockResolvedValue(makePosts(3));
+  });
+
+  it("returns 400 for non-numeric event ID", async () => {
+    const response = await postsRoute.GET(
+      getRequest("not-a-number"),
+      { params: Promise.resolve({ id: "not-a-number" }) },
+    );
+
+    expect(response.status).toBe(400);
+    const body = await response.json() as { error: string };
+    expect(body.error).toBe("Invalid event ID");
+    expect(mockedCheckEventAdminAuth).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when caller is not event admin", async () => {
+    mockedCheckEventAdminAuth.mockResolvedValue({ authorized: false, error: "Forbidden" });
+
+    const response = await postsRoute.GET(
+      getRequest("7"),
+      { params: Promise.resolve({ id: "7" }) },
+    );
+
+    expect(response.status).toBe(403);
+    expect(mockedFindMany).not.toHaveBeenCalled();
+  });
+
+  it("returns posts list with no nextCursor when under limit", async () => {
+    mockedFindMany.mockResolvedValue(makePosts(3));
+
+    const response = await postsRoute.GET(
+      getRequest("7"),
+      { params: Promise.resolve({ id: "7" }) },
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as { posts: unknown[]; nextCursor: unknown };
+    expect(body.posts).toHaveLength(3);
+    expect(body.nextCursor).toBeNull();
+  });
+
+  it("excludes DELETED posts by default (no status param)", async () => {
+    await postsRoute.GET(
+      getRequest("7"),
+      { params: Promise.resolve({ id: "7" }) },
+    );
+
+    expect(mockedFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          status: expect.objectContaining({ not: "DELETED" }),
+        }),
+      }),
+    );
+  });
+
+  it("filters by specific status when status param provided", async () => {
+    await postsRoute.GET(
+      getRequest("7", { status: "PENDING" }),
+      { params: Promise.resolve({ id: "7" }) },
+    );
+
+    expect(mockedFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ status: "PENDING" }),
+      }),
+    );
+  });
+
+  it("returns only DELETED posts when status=DELETED", async () => {
+    await postsRoute.GET(
+      getRequest("7", { status: "DELETED" }),
+      { params: Promise.resolve({ id: "7" }) },
+    );
+
+    expect(mockedFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ status: "DELETED" }),
+      }),
+    );
+  });
+
+  it("ignores invalid status param and falls back to default filter", async () => {
+    await postsRoute.GET(
+      getRequest("7", { status: "BOGUS" }),
+      { params: Promise.resolve({ id: "7" }) },
+    );
+
+    expect(mockedFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          status: expect.objectContaining({ not: "DELETED" }),
+        }),
+      }),
+    );
+  });
+
+  it("paginates: returns nextCursor when more posts exist", async () => {
+    mockedFindMany.mockResolvedValue(makePosts(51));
+
+    const response = await postsRoute.GET(
+      getRequest("7", { limit: "50" }),
+      { params: Promise.resolve({ id: "7" }) },
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as { posts: unknown[]; nextCursor: string };
+    expect(body.posts).toHaveLength(50);
+    expect(body.nextCursor).toBe("post-49");
+  });
+
+  it("passes cursor to findMany when cursor param provided", async () => {
+    await postsRoute.GET(
+      getRequest("7", { cursor: "post-50" }),
+      { params: Promise.resolve({ id: "7" }) },
+    );
+
+    expect(mockedFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cursor: { id: "post-50" },
+        skip: 1,
+      }),
+    );
+  });
+
+  it("clamps limit to 100 even if caller requests more", async () => {
+    mockedFindMany.mockResolvedValue(makePosts(5));
+
+    await postsRoute.GET(
+      getRequest("7", { limit: "999" }),
+      { params: Promise.resolve({ id: "7" }) },
+    );
+
+    expect(mockedFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        take: 101,
+      }),
+    );
+  });
+
+  it("defaults limit to 50 for NaN limit param", async () => {
+    mockedFindMany.mockResolvedValue(makePosts(3));
+
+    await postsRoute.GET(
+      getRequest("7", { limit: "abc" }),
+      { params: Promise.resolve({ id: "7" }) },
+    );
+
+    expect(mockedFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        take: 51,
+      }),
+    );
+  });
+});

--- a/src/app/api/admin/event/[id]/community/posts/route.ts
+++ b/src/app/api/admin/event/[id]/community/posts/route.ts
@@ -1,0 +1,48 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { PostStatus } from "@/generated/prisma";
+import { checkEventAdminAuth } from "@/lib/auth/event-admin";
+import { communityPostInclude, serializeCommunityPost } from "@/lib/community/server";
+import { prisma } from "@/lib/prisma/prisma";
+
+const VALID_STATUSES = Object.values(PostStatus);
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const eventId = Number((await params).id);
+  if (Number.isNaN(eventId)) {
+    return NextResponse.json({ error: "Invalid event ID" }, { status: 400 });
+  }
+
+  const auth = await checkEventAdminAuth(eventId, req.headers);
+  if (!auth.authorized) {
+    return NextResponse.json({ error: auth.error }, { status: 403 });
+  }
+
+  const url = new URL(req.url);
+  const statusParam = url.searchParams.get("status");
+  const cursor = url.searchParams.get("cursor") || undefined;
+  const limit = Math.min(Number(url.searchParams.get("limit") || "50") || 50, 100);
+
+  const statusFilter =
+    statusParam && VALID_STATUSES.includes(statusParam as PostStatus)
+      ? { status: statusParam as PostStatus }
+      : { status: { not: PostStatus.DELETED as PostStatus } };
+
+  const posts = await prisma.communityPost.findMany({
+    where: { eventId, ...statusFilter },
+    include: communityPostInclude,
+    orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+    take: limit + 1,
+    ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+  });
+
+  const hasMore = posts.length > limit;
+  const page = hasMore ? posts.slice(0, limit) : posts;
+
+  return NextResponse.json({
+    posts: page.map(p => serializeCommunityPost(p, auth.user?.id)),
+    nextCursor: hasMore ? (page[page.length - 1]?.id ?? null) : null,
+  });
+}

--- a/src/app/api/community/posts/[postId]/moderate/route.test.ts
+++ b/src/app/api/community/posts/[postId]/moderate/route.test.ts
@@ -1,0 +1,230 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const prismaMock = vi.hoisted(() => ({
+  communityPost: {
+    findUnique: vi.fn(),
+    update: vi.fn(),
+  },
+  postModerationLog: {
+    create: vi.fn(),
+  },
+  $transaction: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+vi.mock("@/lib/auth/event-admin", () => ({
+  checkEventAdminAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/community/server", () => ({
+  softDeletePost: vi.fn(),
+}));
+
+import * as moderateRoute from "./route";
+import { checkEventAdminAuth } from "@/lib/auth/event-admin";
+import { softDeletePost } from "@/lib/community/server";
+
+const mockedCheckEventAdminAuth = checkEventAdminAuth as unknown as ReturnType<typeof vi.fn>;
+const mockedFindPost = prismaMock.communityPost.findUnique as unknown as ReturnType<typeof vi.fn>;
+const mockedUpdatePost = prismaMock.communityPost.update as unknown as ReturnType<typeof vi.fn>;
+const mockedCreateModerationLog = prismaMock.postModerationLog.create as unknown as ReturnType<typeof vi.fn>;
+const mockedTransaction = prismaMock.$transaction as unknown as ReturnType<typeof vi.fn>;
+const mockedSoftDeletePost = softDeletePost as unknown as ReturnType<typeof vi.fn>;
+
+function postRequest(body: unknown) {
+  return new NextRequest("http://localhost/api/community/posts/post-abc/moderate", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function activePost(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "post-abc",
+    eventId: 7,
+    status: "PENDING",
+    pinned: false,
+    ...overrides,
+  };
+}
+
+function authorizedAdmin() {
+  return {
+    authorized: true,
+    adminId: "admin-1",
+    user: { id: "user-admin", email: "admin@example.com" },
+  };
+}
+
+describe("POST /api/community/posts/[postId]/moderate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedCheckEventAdminAuth.mockResolvedValue(authorizedAdmin());
+    mockedFindPost.mockResolvedValue(activePost());
+    mockedUpdatePost.mockReturnValue({ query: "update-post" });
+    mockedCreateModerationLog.mockReturnValue({ query: "create-log" });
+    mockedTransaction.mockResolvedValue([
+      { id: "post-abc", status: "APPROVED", pinned: false },
+      {},
+    ]);
+  });
+
+  it("returns 422 for missing action", async () => {
+    const response = await moderateRoute.POST(
+      postRequest({}),
+      { params: Promise.resolve({ postId: "post-abc" }) },
+    );
+
+    expect(response.status).toBe(422);
+    expect(mockedFindPost).not.toHaveBeenCalled();
+  });
+
+  it("returns 422 for invalid action value", async () => {
+    const response = await moderateRoute.POST(
+      postRequest({ action: "ban" }),
+      { params: Promise.resolve({ postId: "post-abc" }) },
+    );
+
+    expect(response.status).toBe(422);
+    expect(mockedFindPost).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when post does not exist", async () => {
+    mockedFindPost.mockResolvedValue(null);
+
+    const response = await moderateRoute.POST(
+      postRequest({ action: "approve" }),
+      { params: Promise.resolve({ postId: "no-such-post" }) },
+    );
+
+    expect(response.status).toBe(404);
+    expect(mockedCheckEventAdminAuth).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when post is already deleted", async () => {
+    mockedFindPost.mockResolvedValue(activePost({ status: "DELETED" }));
+
+    const response = await moderateRoute.POST(
+      postRequest({ action: "approve" }),
+      { params: Promise.resolve({ postId: "post-abc" }) },
+    );
+
+    expect(response.status).toBe(404);
+    expect(mockedCheckEventAdminAuth).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when caller is not event admin", async () => {
+    mockedCheckEventAdminAuth.mockResolvedValue({ authorized: false, error: "Forbidden" });
+
+    const response = await moderateRoute.POST(
+      postRequest({ action: "approve" }),
+      { params: Promise.resolve({ postId: "post-abc" }) },
+    );
+
+    expect(response.status).toBe(403);
+    expect(mockedTransaction).not.toHaveBeenCalled();
+  });
+
+  it("calls softDeletePost and returns 200 for remove action", async () => {
+    mockedSoftDeletePost.mockResolvedValue(undefined);
+
+    const response = await moderateRoute.POST(
+      postRequest({ action: "remove" }),
+      { params: Promise.resolve({ postId: "post-abc" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ action: "removed" });
+    expect(mockedSoftDeletePost).toHaveBeenCalledWith({
+      postId: "post-abc",
+      actor: expect.objectContaining({ id: "user-admin", isAdmin: true, adminId: "admin-1" }),
+    });
+    expect(mockedTransaction).not.toHaveBeenCalled();
+  });
+
+  it("approves post atomically and returns updated post", async () => {
+    mockedTransaction.mockResolvedValue([
+      { id: "post-abc", status: "APPROVED", pinned: false },
+      {},
+    ]);
+
+    const response = await moderateRoute.POST(
+      postRequest({ action: "approve" }),
+      { params: Promise.resolve({ postId: "post-abc" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      post: { id: "post-abc", status: "APPROVED", pinned: false },
+    });
+    expect(mockedTransaction).toHaveBeenCalledWith(expect.arrayContaining([expect.anything(), expect.anything()]));
+    expect(mockedSoftDeletePost).not.toHaveBeenCalled();
+  });
+
+  it("rejects post and logs reason atomically", async () => {
+    mockedTransaction.mockResolvedValue([
+      { id: "post-abc", status: "REJECTED", pinned: false },
+      {},
+    ]);
+
+    const response = await moderateRoute.POST(
+      postRequest({ action: "reject", reason: "Inappropriate content" }),
+      { params: Promise.resolve({ postId: "post-abc" }) },
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as { post: { status: string } };
+    expect(body.post.status).toBe("REJECTED");
+  });
+
+  it("pins post without changing its status", async () => {
+    mockedFindPost.mockResolvedValue(activePost({ status: "APPROVED", pinned: false }));
+    mockedTransaction.mockResolvedValue([
+      { id: "post-abc", status: "APPROVED", pinned: true },
+      {},
+    ]);
+
+    const response = await moderateRoute.POST(
+      postRequest({ action: "pin" }),
+      { params: Promise.resolve({ postId: "post-abc" }) },
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as { post: { pinned: boolean; status: string } };
+    expect(body.post.pinned).toBe(true);
+    expect(body.post.status).toBe("APPROVED");
+  });
+
+  it("unpins post without changing its status", async () => {
+    mockedFindPost.mockResolvedValue(activePost({ status: "APPROVED", pinned: true }));
+    mockedTransaction.mockResolvedValue([
+      { id: "post-abc", status: "APPROVED", pinned: false },
+      {},
+    ]);
+
+    const response = await moderateRoute.POST(
+      postRequest({ action: "unpin" }),
+      { params: Promise.resolve({ postId: "post-abc" }) },
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as { post: { pinned: boolean } };
+    expect(body.post.pinned).toBe(false);
+  });
+
+  it("uses post's own eventId for auth check", async () => {
+    mockedFindPost.mockResolvedValue(activePost({ eventId: 42 }));
+
+    await moderateRoute.POST(
+      postRequest({ action: "approve" }),
+      { params: Promise.resolve({ postId: "post-abc" }) },
+    );
+
+    expect(mockedCheckEventAdminAuth).toHaveBeenCalledWith(42, expect.anything());
+  });
+});

--- a/src/app/api/community/posts/[postId]/moderate/route.ts
+++ b/src/app/api/community/posts/[postId]/moderate/route.ts
@@ -1,0 +1,84 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { ModerationAction, PostStatus } from "@/generated/prisma";
+import { checkEventAdminAuth } from "@/lib/auth/event-admin";
+import { softDeletePost } from "@/lib/community/server";
+import { prisma } from "@/lib/prisma/prisma";
+import { moderateCommunityPostSchema } from "@/types/schemas/community";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ postId: string }> },
+) {
+  const { postId } = await params;
+
+  const body = await req.json().catch(() => null);
+  const parsed = moderateCommunityPostSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.issues }, { status: 422 });
+  }
+
+  const post = await prisma.communityPost.findUnique({
+    where: { id: postId },
+    select: { id: true, eventId: true, status: true },
+  });
+
+  if (!post || post.status === PostStatus.DELETED) {
+    return NextResponse.json({ error: "Post not found" }, { status: 404 });
+  }
+
+  const auth = await checkEventAdminAuth(post.eventId, req.headers);
+  if (!auth.authorized) {
+    return NextResponse.json({ error: auth.error }, { status: 403 });
+  }
+
+  const actor = {
+    id: auth.user!.id,
+    isAdmin: true,
+    adminId: auth.adminId || null,
+  };
+
+  const { action, reason } = parsed.data;
+
+  if (action === "remove") {
+    await softDeletePost({ postId, actor });
+    return NextResponse.json({ action: "removed" }, { status: 200 });
+  }
+
+  const statusMap = {
+    approve: PostStatus.APPROVED,
+    reject: PostStatus.REJECTED,
+  } as const;
+
+  const logActionMap = {
+    approve: ModerationAction.APPROVED,
+    reject: ModerationAction.REJECTED,
+    pin: ModerationAction.PINNED,
+    unpin: ModerationAction.UNPINNED,
+  } as const;
+
+  const [updated] = await prisma.$transaction([
+    prisma.communityPost.update({
+      where: { id: postId },
+      data: {
+        ...(action in statusMap ? { status: statusMap[action as keyof typeof statusMap] } : {}),
+        ...(action === "pin" ? { pinned: true } : {}),
+        ...(action === "unpin" ? { pinned: false } : {}),
+      },
+    }),
+    prisma.postModerationLog.create({
+      data: {
+        postId,
+        actorUserId: actor.id,
+        actorAdminId: actor.adminId,
+        action: logActionMap[action as keyof typeof logActionMap],
+        reason: reason ?? null,
+        metadata: {},
+      },
+    }),
+  ]);
+
+  return NextResponse.json(
+    { post: { id: updated.id, status: updated.status, pinned: updated.pinned } },
+    { status: 200 },
+  );
+}

--- a/src/app/api/community/posts/bulk-moderate/route.test.ts
+++ b/src/app/api/community/posts/bulk-moderate/route.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const prismaMock = vi.hoisted(() => ({
+  communityPost: {
+    findMany: vi.fn(),
+    updateMany: vi.fn(),
+  },
+  postModerationLog: {
+    create: vi.fn(),
+  },
+  $transaction: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+vi.mock("@/lib/auth/event-admin", () => ({
+  checkEventAdminAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/community/server", () => ({
+  softDeletePost: vi.fn(),
+}));
+
+import * as bulkRoute from "./route";
+import { checkEventAdminAuth } from "@/lib/auth/event-admin";
+import { softDeletePost } from "@/lib/community/server";
+
+const mockedCheckEventAdminAuth = checkEventAdminAuth as unknown as ReturnType<typeof vi.fn>;
+const mockedFindMany = prismaMock.communityPost.findMany as unknown as ReturnType<typeof vi.fn>;
+const mockedTransaction = prismaMock.$transaction as unknown as ReturnType<typeof vi.fn>;
+const mockedSoftDeletePost = softDeletePost as unknown as ReturnType<typeof vi.fn>;
+
+function postRequest(body: unknown) {
+  return new NextRequest("http://localhost/api/community/posts/bulk-moderate", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function authorizedAdmin() {
+  return {
+    authorized: true,
+    adminId: "admin-1",
+    user: { id: "user-admin", email: "admin@example.com" },
+  };
+}
+
+describe("POST /api/community/posts/bulk-moderate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedCheckEventAdminAuth.mockResolvedValue(authorizedAdmin());
+    mockedFindMany.mockResolvedValue([{ id: "post-1" }, { id: "post-2" }]);
+    mockedTransaction.mockResolvedValue([{}, {}, {}]);
+    mockedSoftDeletePost.mockResolvedValue(undefined);
+  });
+
+  it("returns 422 for missing eventId", async () => {
+    const response = await bulkRoute.POST(
+      postRequest({ postIds: ["post-1"], action: "approve" }),
+    );
+
+    expect(response.status).toBe(422);
+    expect(mockedCheckEventAdminAuth).not.toHaveBeenCalled();
+  });
+
+  it("returns 422 for empty postIds array", async () => {
+    const response = await bulkRoute.POST(
+      postRequest({ eventId: 7, postIds: [], action: "approve" }),
+    );
+
+    expect(response.status).toBe(422);
+  });
+
+  it("returns 422 for invalid action", async () => {
+    const response = await bulkRoute.POST(
+      postRequest({ eventId: 7, postIds: ["post-1"], action: "pin" }),
+    );
+
+    expect(response.status).toBe(422);
+  });
+
+  it("returns 403 when caller is not event admin", async () => {
+    mockedCheckEventAdminAuth.mockResolvedValue({ authorized: false, error: "Forbidden" });
+
+    const response = await bulkRoute.POST(
+      postRequest({ eventId: 7, postIds: ["post-1"], action: "approve" }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(mockedFindMany).not.toHaveBeenCalled();
+  });
+
+  it("filters posts to valid IDs within the event", async () => {
+    mockedFindMany.mockResolvedValue([{ id: "post-1" }]);
+
+    const response = await bulkRoute.POST(
+      postRequest({ eventId: 7, postIds: ["post-1", "post-other-event"], action: "approve" }),
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as { processed: number; skipped: number };
+    expect(body.processed).toBe(1);
+    expect(body.skipped).toBe(1);
+    expect(mockedFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ eventId: 7 }),
+      }),
+    );
+  });
+
+  it("uses softDeletePost loop for remove action", async () => {
+    mockedFindMany.mockResolvedValue([{ id: "post-1" }, { id: "post-2" }]);
+
+    const response = await bulkRoute.POST(
+      postRequest({ eventId: 7, postIds: ["post-1", "post-2"], action: "remove" }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockedSoftDeletePost).toHaveBeenCalledTimes(2);
+    expect(mockedSoftDeletePost).toHaveBeenCalledWith({
+      postId: "post-1",
+      actor: expect.objectContaining({ id: "user-admin", isAdmin: true }),
+    });
+    expect(mockedSoftDeletePost).toHaveBeenCalledWith({
+      postId: "post-2",
+      actor: expect.objectContaining({ id: "user-admin", isAdmin: true }),
+    });
+    expect(mockedTransaction).not.toHaveBeenCalled();
+  });
+
+  it("uses $transaction for approve action", async () => {
+    mockedFindMany.mockResolvedValue([{ id: "post-1" }, { id: "post-2" }]);
+
+    const response = await bulkRoute.POST(
+      postRequest({ eventId: 7, postIds: ["post-1", "post-2"], action: "approve" }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockedTransaction).toHaveBeenCalledOnce();
+    expect(mockedSoftDeletePost).not.toHaveBeenCalled();
+    const body = await response.json() as { processed: number; skipped: number };
+    expect(body).toEqual({ processed: 2, skipped: 0 });
+  });
+
+  it("uses $transaction for reject action with reason", async () => {
+    mockedFindMany.mockResolvedValue([{ id: "post-1" }]);
+
+    const response = await bulkRoute.POST(
+      postRequest({ eventId: 7, postIds: ["post-1"], action: "reject", reason: "Spam" }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockedTransaction).toHaveBeenCalledOnce();
+    const body = await response.json() as { processed: number; skipped: number };
+    expect(body.processed).toBe(1);
+  });
+
+  it("returns processed=0 skipped=N when all posts are from another event", async () => {
+    mockedFindMany.mockResolvedValue([]);
+
+    const response = await bulkRoute.POST(
+      postRequest({ eventId: 7, postIds: ["post-x", "post-y"], action: "approve" }),
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as { processed: number; skipped: number };
+    expect(body).toEqual({ processed: 0, skipped: 2 });
+  });
+
+  it("checks auth against the eventId in body, not post's event", async () => {
+    await bulkRoute.POST(
+      postRequest({ eventId: 42, postIds: ["post-1"], action: "approve" }),
+    );
+
+    expect(mockedCheckEventAdminAuth).toHaveBeenCalledWith(42, expect.anything());
+  });
+});

--- a/src/app/api/community/posts/bulk-moderate/route.ts
+++ b/src/app/api/community/posts/bulk-moderate/route.ts
@@ -1,0 +1,78 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { ModerationAction, PostStatus } from "@/generated/prisma";
+import { checkEventAdminAuth } from "@/lib/auth/event-admin";
+import { softDeletePost } from "@/lib/community/server";
+import { prisma } from "@/lib/prisma/prisma";
+import { bulkModerateCommunityPostsSchema } from "@/types/schemas/community";
+
+export async function POST(req: NextRequest) {
+  const body = await req.json().catch(() => null);
+  const parsed = bulkModerateCommunityPostsSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.issues }, { status: 422 });
+  }
+
+  const { eventId, postIds, action, reason } = parsed.data;
+
+  const auth = await checkEventAdminAuth(eventId, req.headers);
+  if (!auth.authorized) {
+    return NextResponse.json({ error: auth.error }, { status: 403 });
+  }
+
+  const actor = {
+    id: auth.user!.id,
+    isAdmin: true,
+    adminId: auth.adminId || null,
+  };
+
+  const posts = await prisma.communityPost.findMany({
+    where: {
+      id: { in: postIds },
+      eventId,
+      status: { not: PostStatus.DELETED },
+    },
+    select: { id: true },
+  });
+
+  const validIds = posts.map(p => p.id);
+
+  if (action === "remove") {
+    for (const postId of validIds) {
+      await softDeletePost({ postId, actor });
+    }
+  } else {
+    const statusMap = {
+      approve: PostStatus.APPROVED,
+      reject: PostStatus.REJECTED,
+    } as const;
+
+    const logActionMap = {
+      approve: ModerationAction.APPROVED,
+      reject: ModerationAction.REJECTED,
+    } as const;
+
+    await prisma.$transaction([
+      prisma.communityPost.updateMany({
+        where: { id: { in: validIds } },
+        data: { status: statusMap[action] },
+      }),
+      ...validIds.map(postId =>
+        prisma.postModerationLog.create({
+          data: {
+            postId,
+            actorUserId: actor.id,
+            actorAdminId: actor.adminId,
+            action: logActionMap[action],
+            reason: reason || null,
+            metadata: {},
+          },
+        }),
+      ),
+    ]);
+  }
+
+  return NextResponse.json(
+    { processed: validIds.length, skipped: postIds.length - validIds.length },
+    { status: 200 },
+  );
+}

--- a/src/components/admin/community/CommunityModerationPanel.tsx
+++ b/src/components/admin/community/CommunityModerationPanel.tsx
@@ -1,0 +1,664 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  Alert,
+  Avatar,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  IconButton,
+  Paper,
+  Stack,
+  Tab,
+  Tabs,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import {
+  CheckCircle,
+  Delete,
+  History as HistoryIcon,
+  PushPin,
+  PushPinOutlined,
+  Refresh,
+  ThumbDown,
+} from "@mui/icons-material";
+import type { CommunityPostView } from "@/components/events/community/types";
+
+type PostStatus = "PENDING" | "APPROVED" | "REJECTED" | "DELETED";
+
+type ModerationLog = {
+  id: string;
+  postId: string;
+  action: string;
+  reason: string | null;
+  createdAt: string;
+  post: { id: string; type: string; content: string | null; status: string };
+  actor: { id: string; name: string | null; email: string } | null;
+};
+
+interface CommunityModerationPanelProps {
+  eventId: number;
+  communityModerated: boolean;
+}
+
+const STATUS_COLORS: Record<PostStatus, "warning" | "success" | "error" | "default"> = {
+  PENDING: "warning",
+  APPROVED: "success",
+  REJECTED: "error",
+  DELETED: "default",
+};
+
+const ACTION_LABELS: Record<string, string> = {
+  CREATED: "Created",
+  APPROVED: "Approved",
+  REJECTED: "Rejected",
+  DELETED: "Removed",
+  PINNED: "Pinned",
+  UNPINNED: "Unpinned",
+};
+
+export default function CommunityModerationPanel({
+  eventId,
+  communityModerated,
+}: CommunityModerationPanelProps) {
+  const [tab, setTab] = useState(0);
+  const [posts, setPosts] = useState<CommunityPostView[]>([]);
+  const [logs, setLogs] = useState<ModerationLog[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [logsLoading, setLogsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [bulkLoading, setBulkLoading] = useState(false);
+  const [statusFilter, setStatusFilter] = useState<PostStatus | "ALL">("PENDING");
+  const [rejectDialog, setRejectDialog] = useState<{ postId: string; bulk: boolean } | null>(null);
+  const [rejectReason, setRejectReason] = useState("");
+
+  const fetchPosts = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    setSelectedIds(new Set());
+    try {
+      const params = new URLSearchParams();
+      if (statusFilter !== "ALL") params.set("status", statusFilter);
+      params.set("limit", "50");
+      const res = await fetch(`/api/admin/event/${eventId}/community/posts?${params}`);
+      const data = await res.json() as { posts?: CommunityPostView[]; error?: string };
+      if (!res.ok) throw new Error(data.error || "Failed to load posts");
+      setPosts(data.posts ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load posts");
+    } finally {
+      setLoading(false);
+    }
+  }, [eventId, statusFilter]);
+
+  const fetchLogs = useCallback(async () => {
+    setLogsLoading(true);
+    try {
+      const res = await fetch(`/api/admin/event/${eventId}/community/logs?limit=50`);
+      const data = await res.json() as { logs?: ModerationLog[]; error?: string };
+      if (!res.ok) throw new Error(data.error || "Failed to load logs");
+      setLogs(data.logs ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load logs");
+    } finally {
+      setLogsLoading(false);
+    }
+  }, [eventId]);
+
+  useEffect(() => {
+    if (tab === 3) {
+      void fetchLogs();
+    } else {
+      void fetchPosts();
+    }
+  }, [tab, fetchPosts, fetchLogs]);
+
+  const handleTabChange = (_: React.SyntheticEvent, v: number) => {
+    setTab(v);
+    if (v === 0) setStatusFilter("PENDING");
+    else if (v === 1) setStatusFilter("ALL");
+    else if (v === 2) setStatusFilter("DELETED");
+  };
+
+  const moderate = async (postId: string, action: string, reason?: string) => {
+    setActionLoading(postId);
+    setError(null);
+    try {
+      const res = await fetch(`/api/community/posts/${postId}/moderate`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action, reason: reason || undefined }),
+      });
+      const data = await res.json() as { error?: string };
+      if (!res.ok) throw new Error(data.error || "Action failed");
+      if (action === "remove") {
+        setPosts(current => current.filter(p => p.id !== postId));
+      } else {
+        await fetchPosts();
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Action failed");
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const bulkModerate = async (action: string, reason?: string) => {
+    if (selectedIds.size === 0) return;
+    setBulkLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/community/posts/bulk-moderate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          eventId,
+          postIds: Array.from(selectedIds),
+          action,
+          reason: reason || undefined,
+        }),
+      });
+      const data = await res.json() as { processed?: number; skipped?: number; error?: string };
+      if (!res.ok) throw new Error(data.error || "Bulk action failed");
+      await fetchPosts();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Bulk action failed");
+    } finally {
+      setBulkLoading(false);
+      setRejectDialog(null);
+      setRejectReason("");
+    }
+  };
+
+  const toggleSelect = (id: string) => {
+    setSelectedIds(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const selectAll = () => {
+    if (selectedIds.size === posts.length) {
+      setSelectedIds(new Set());
+    } else {
+      setSelectedIds(new Set(posts.map(p => p.id)));
+    }
+  };
+
+  const openRejectDialog = (postId: string) => {
+    setRejectDialog({ postId, bulk: false });
+    setRejectReason("");
+  };
+
+  const openBulkRejectDialog = () => {
+    setRejectDialog({ postId: "", bulk: true });
+    setRejectReason("");
+  };
+
+  const handleRejectConfirm = async () => {
+    if (!rejectDialog) return;
+    if (rejectDialog.bulk) {
+      await bulkModerate("reject", rejectReason);
+    } else {
+      await moderate(rejectDialog.postId, "reject", rejectReason);
+      setRejectDialog(null);
+      setRejectReason("");
+    }
+  };
+
+  const PostActions = ({ post }: { post: CommunityPostView }) => {
+    const busy = actionLoading === post.id;
+    return (
+      <Stack direction="row" spacing={0.5}>
+        {post.status === "PENDING" && (
+          <Tooltip title="Approve">
+            <span>
+              <IconButton
+                size="small"
+                color="success"
+                disabled={busy}
+                onClick={() => void moderate(post.id, "approve")}
+              >
+                {busy ? <CircularProgress size={16} /> : <CheckCircle fontSize="small" />}
+              </IconButton>
+            </span>
+          </Tooltip>
+        )}
+        {post.status !== "REJECTED" && post.status !== "DELETED" && (
+          <Tooltip title="Reject">
+            <span>
+              <IconButton
+                size="small"
+                color="error"
+                disabled={busy}
+                onClick={() => openRejectDialog(post.id)}
+              >
+                <ThumbDown fontSize="small" />
+              </IconButton>
+            </span>
+          </Tooltip>
+        )}
+        {post.status !== "DELETED" && (
+          <>
+            <Tooltip title={post.pinned ? "Unpin" : "Pin to top"}>
+              <span>
+                <IconButton
+                  size="small"
+                  color={post.pinned ? "primary" : "default"}
+                  disabled={busy}
+                  onClick={() => void moderate(post.id, post.pinned ? "unpin" : "pin")}
+                >
+                  {post.pinned ? <PushPin fontSize="small" /> : <PushPinOutlined fontSize="small" />}
+                </IconButton>
+              </span>
+            </Tooltip>
+            <Tooltip title="Remove">
+              <span>
+                <IconButton
+                  size="small"
+                  color="error"
+                  disabled={busy}
+                  onClick={() => void moderate(post.id, "remove")}
+                >
+                  <Delete fontSize="small" />
+                </IconButton>
+              </span>
+            </Tooltip>
+          </>
+        )}
+      </Stack>
+    );
+  };
+
+  return (
+    <Box>
+      <Stack direction="row" justifyContent="space-between" alignItems="flex-start" flexWrap="wrap" gap={1} mb={3}>
+        <Typography variant="h4">Community Moderation</Typography>
+        {!communityModerated && (
+          <Alert severity="info" sx={{ py: 0.5 }}>
+            Moderation is disabled — posts auto-approve.
+          </Alert>
+        )}
+      </Stack>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
+
+      <Paper>
+        <Tabs
+          value={tab}
+          onChange={handleTabChange}
+          sx={{ borderBottom: 1, borderColor: "divider" }}
+          variant="scrollable"
+          scrollButtons="auto"
+        >
+          <Tab label="Pending" />
+          <Tab label="All Posts" />
+          <Tab label="Deleted" />
+          <Tab label="Audit Log" />
+        </Tabs>
+
+        <Box sx={{ p: { xs: 1, sm: 2 } }}>
+          {tab === 0 && (
+            <PostList
+              posts={posts}
+              loading={loading}
+              selectedIds={selectedIds}
+              bulkLoading={bulkLoading}
+              onToggleSelect={toggleSelect}
+              onSelectAll={selectAll}
+              onBulkApprove={() => void bulkModerate("approve")}
+              onBulkReject={openBulkRejectDialog}
+              onBulkRemove={() => void bulkModerate("remove")}
+              onRefresh={() => void fetchPosts()}
+              PostActions={PostActions}
+              showStatusBadge={false}
+            />
+          )}
+
+          {tab === 1 && (
+            <Box>
+              <Stack direction="row" spacing={1} mb={2} alignItems="center" flexWrap="wrap" useFlexGap>
+                {(["ALL", "PENDING", "APPROVED", "REJECTED"] as const).map(s => (
+                  <Button
+                    key={s}
+                    size="small"
+                    variant={statusFilter === s ? "contained" : "outlined"}
+                    onClick={() => { setStatusFilter(s); }}
+                  >
+                    {s === "ALL" ? "All" : s.charAt(0) + s.slice(1).toLowerCase()}
+                  </Button>
+                ))}
+                <IconButton size="small" onClick={() => void fetchPosts()}>
+                  <Refresh fontSize="small" />
+                </IconButton>
+              </Stack>
+              <PostList
+                posts={posts}
+                loading={loading}
+                selectedIds={selectedIds}
+                bulkLoading={bulkLoading}
+                onToggleSelect={toggleSelect}
+                onSelectAll={selectAll}
+                onBulkApprove={() => void bulkModerate("approve")}
+                onBulkReject={openBulkRejectDialog}
+                onBulkRemove={() => void bulkModerate("remove")}
+                onRefresh={() => void fetchPosts()}
+                PostActions={PostActions}
+                showStatusBadge
+              />
+            </Box>
+          )}
+
+          {tab === 2 && (
+            <PostList
+              posts={posts}
+              loading={loading}
+              selectedIds={selectedIds}
+              bulkLoading={bulkLoading}
+              onToggleSelect={toggleSelect}
+              onSelectAll={selectAll}
+              onBulkApprove={() => void bulkModerate("approve")}
+              onBulkReject={openBulkRejectDialog}
+              onBulkRemove={() => void bulkModerate("remove")}
+              onRefresh={() => void fetchPosts()}
+              PostActions={PostActions}
+              showStatusBadge={false}
+            />
+          )}
+
+          {tab === 3 && (
+            <AuditLogView logs={logs} loading={logsLoading} onRefresh={() => void fetchLogs()} />
+          )}
+        </Box>
+      </Paper>
+
+      <Dialog open={Boolean(rejectDialog)} onClose={() => setRejectDialog(null)} maxWidth="sm" fullWidth>
+        <DialogTitle>
+          {rejectDialog?.bulk ? `Reject ${selectedIds.size} post(s)` : "Reject Post"}
+        </DialogTitle>
+        <DialogContent>
+          <TextField
+            autoFocus
+            fullWidth
+            multiline
+            rows={3}
+            label="Reason (optional)"
+            value={rejectReason}
+            onChange={e => setRejectReason(e.target.value)}
+            sx={{ mt: 1 }}
+            placeholder="Reason visible in audit log..."
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setRejectDialog(null)}>Cancel</Button>
+          <Button
+            variant="contained"
+            color="error"
+            onClick={() => void handleRejectConfirm()}
+            disabled={Boolean(actionLoading) || bulkLoading}
+          >
+            Reject
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}
+
+function PostList({
+  posts,
+  loading,
+  selectedIds,
+  bulkLoading,
+  onToggleSelect,
+  onSelectAll,
+  onBulkApprove,
+  onBulkReject,
+  onBulkRemove,
+  onRefresh,
+  PostActions,
+  showStatusBadge,
+}: {
+  posts: CommunityPostView[];
+  loading: boolean;
+  selectedIds: Set<string>;
+  bulkLoading: boolean;
+  onToggleSelect: (id: string) => void;
+  onSelectAll: () => void;
+  onBulkApprove: () => void;
+  onBulkReject: () => void;
+  onBulkRemove: () => void;
+  onRefresh: () => void;
+  PostActions: React.ComponentType<{ post: CommunityPostView }>;
+  showStatusBadge: boolean;
+}) {
+  if (loading) {
+    return (
+      <Box sx={{ py: 6, textAlign: "center" }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      <Stack direction="row" justifyContent="space-between" alignItems="flex-start" flexWrap="wrap" gap={1} mb={2}>
+        <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap>
+          {selectedIds.size > 0 && (
+            <>
+              <Typography variant="body2" color="text.secondary" sx={{ alignSelf: "center" }}>
+                {selectedIds.size} selected
+              </Typography>
+              <Button size="small" variant="outlined" color="success" disabled={bulkLoading} onClick={onBulkApprove}>
+                Approve
+              </Button>
+              <Button size="small" variant="outlined" color="warning" disabled={bulkLoading} onClick={onBulkReject}>
+                Reject
+              </Button>
+              <Button size="small" variant="outlined" color="error" disabled={bulkLoading} onClick={onBulkRemove}>
+                Remove
+              </Button>
+            </>
+          )}
+        </Stack>
+        <Stack direction="row" spacing={1} alignItems="center">
+          {posts.length > 0 && (
+            <Button size="small" variant="text" onClick={onSelectAll}>
+              {selectedIds.size === posts.length ? "Deselect all" : "Select all"}
+            </Button>
+          )}
+          <IconButton size="small" onClick={onRefresh}>
+            <Refresh fontSize="small" />
+          </IconButton>
+        </Stack>
+      </Stack>
+
+      {posts.length === 0 ? (
+        <Alert severity="info">No posts.</Alert>
+      ) : (
+        <Stack spacing={1}>
+          {posts.map(post => (
+            <PostRow
+              key={post.id}
+              post={post}
+              selected={selectedIds.has(post.id)}
+              onToggleSelect={() => onToggleSelect(post.id)}
+              PostActions={PostActions}
+              showStatusBadge={showStatusBadge}
+            />
+          ))}
+        </Stack>
+      )}
+    </Box>
+  );
+}
+
+function PostRow({
+  post,
+  selected,
+  onToggleSelect,
+  PostActions,
+  showStatusBadge,
+}: {
+  post: CommunityPostView;
+  selected: boolean;
+  onToggleSelect: () => void;
+  PostActions: React.ComponentType<{ post: CommunityPostView }>;
+  showStatusBadge: boolean;
+}) {
+  return (
+    <Paper
+      variant="outlined"
+      sx={{
+        p: { xs: 1.5, sm: 2 },
+        cursor: "pointer",
+        bgcolor: selected ? "action.selected" : undefined,
+        borderColor: selected ? "primary.main" : undefined,
+      }}
+      onClick={onToggleSelect}
+    >
+      <Stack direction="row" spacing={1.5} alignItems="flex-start">
+        <Avatar
+          src={post.author.imageUrl || undefined}
+          sx={{ width: 32, height: 32, flexShrink: 0, mt: 0.25 }}
+        />
+        <Box flex={1} minWidth={0}>
+          <Stack direction="row" spacing={0.75} alignItems="center" mb={0.5} flexWrap="wrap" useFlexGap>
+            <Typography variant="subtitle2" fontWeight="bold">
+              {post.author.name}
+            </Typography>
+            <Chip label={post.type} size="small" variant="outlined" />
+            {showStatusBadge && (
+              <Chip
+                label={post.status}
+                size="small"
+                color={STATUS_COLORS[post.status as PostStatus] ?? "default"}
+              />
+            )}
+            {post.pinned && <Chip label="Pinned" size="small" color="primary" />}
+            <Typography variant="caption" color="text.secondary">
+              {new Date(post.createdAt).toLocaleString()}
+            </Typography>
+          </Stack>
+          {post.content && (
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{
+                display: "-webkit-box",
+                WebkitLineClamp: 3,
+                WebkitBoxOrient: "vertical",
+                overflow: "hidden",
+                wordBreak: "break-word",
+              }}
+            >
+              {post.content}
+            </Typography>
+          )}
+          {post.imageUrls.length > 0 && (
+            <Typography variant="caption" color="text.secondary">
+              {post.imageUrls.length} image(s)
+            </Typography>
+          )}
+          {post.linkUrl && (
+            <Typography variant="caption" color="text.secondary" sx={{ wordBreak: "break-all" }} display="block">
+              {post.linkUrl}
+            </Typography>
+          )}
+          <Box mt={0.5} onClick={e => e.stopPropagation()}>
+            <PostActions post={post} />
+          </Box>
+        </Box>
+      </Stack>
+    </Paper>
+  );
+}
+
+function AuditLogView({
+  logs,
+  loading,
+  onRefresh,
+}: {
+  logs: ModerationLog[];
+  loading: boolean;
+  onRefresh: () => void;
+}) {
+  if (loading) {
+    return (
+      <Box sx={{ py: 6, textAlign: "center" }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      <Stack direction="row" justifyContent="flex-end" mb={2}>
+        <IconButton size="small" onClick={onRefresh}>
+          <Refresh fontSize="small" />
+        </IconButton>
+      </Stack>
+      {logs.length === 0 ? (
+        <Alert severity="info">No moderation actions recorded.</Alert>
+      ) : (
+        <Stack spacing={1}>
+          {logs.map(log => (
+            <Paper key={log.id} variant="outlined" sx={{ p: 2 }}>
+              <Stack direction="row" justifyContent="space-between" alignItems="flex-start">
+                <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+                  <HistoryIcon fontSize="small" color="action" />
+                  <Chip
+                    label={ACTION_LABELS[log.action] ?? log.action}
+                    size="small"
+                    color={
+                      log.action === "APPROVED" ? "success"
+                        : log.action === "REJECTED" || log.action === "DELETED" ? "error"
+                        : log.action === "PINNED" ? "primary"
+                        : "default"
+                    }
+                  />
+                  <Typography variant="body2">
+                    post <code>{log.postId.slice(-8)}</code>
+                  </Typography>
+                  {log.actor && (
+                    <Typography variant="caption" color="text.secondary">
+                      by {log.actor.name || log.actor.email}
+                    </Typography>
+                  )}
+                </Stack>
+                <Typography variant="caption" color="text.secondary" flexShrink={0} ml={1}>
+                  {new Date(log.createdAt).toLocaleString()}
+                </Typography>
+              </Stack>
+              {log.reason && (
+                <>
+                  <Divider sx={{ my: 1 }} />
+                  <Typography variant="caption" color="text.secondary" fontStyle="italic">
+                    &quot;{log.reason}&quot;
+                  </Typography>
+                </>
+              )}
+            </Paper>
+          ))}
+        </Stack>
+      )}
+    </Box>
+  );
+}

--- a/src/components/events/community/CommunityPostCard.tsx
+++ b/src/components/events/community/CommunityPostCard.tsx
@@ -4,6 +4,8 @@ import {
   Avatar,
   Box,
   Button,
+  Chip,
+  Divider,
   IconButton,
   Link as MuiLink,
   Paper,
@@ -12,7 +14,7 @@ import {
   Tooltip,
   Typography,
 } from "@mui/material";
-import { Celebration, Delete, Favorite, Lightbulb, Link as LinkIcon, ThumbUp } from "@mui/icons-material";
+import { Celebration, CheckCircle, Delete, Favorite, Lightbulb, Link as LinkIcon, PushPin, PushPinOutlined, ThumbDown, ThumbUp } from "@mui/icons-material";
 import Image from "next/image";
 import NextLink from "next/link";
 import type { ReactNode } from "react";
@@ -46,21 +48,38 @@ function initials(name: string) {
     .toUpperCase();
 }
 
+type ModerateAction = "approve" | "reject" | "pin" | "unpin" | "remove";
+
+const STATUS_CHIP_COLOR = {
+  PENDING: "warning",
+  APPROVED: "success",
+  REJECTED: "error",
+  DELETED: "default",
+} as const;
+
 interface CommunityPostCardProps {
   post: CommunityPostView;
   canDelete: boolean;
+  canModerate?: boolean;
+  communityModerated?: boolean;
   deleteDisabled?: boolean;
+  moderateDisabled?: boolean;
   reactionDisabled?: boolean;
   onDelete: (postId: string) => void;
+  onModerate?: (postId: string, action: ModerateAction) => void;
   onReact: (postId: string, reaction: CommunityReactionKey) => void;
 }
 
 export default function CommunityPostCard({
   post,
   canDelete,
+  canModerate,
+  communityModerated = true,
   deleteDisabled,
+  moderateDisabled,
   reactionDisabled,
   onDelete,
+  onModerate,
   onReact,
 }: CommunityPostCardProps) {
   const createdAt = new Intl.DateTimeFormat("en-US", {
@@ -72,8 +91,8 @@ export default function CommunityPostCard({
   return (
     <Paper variant="outlined" sx={{ p: 2.5, borderRadius: 2 }}>
       <Stack spacing={2}>
-        <Stack direction="row" spacing={1.5} alignItems="center">
-          <NextLink href={`/profile/${post.author.id}`} style={{ textDecoration: "none" }}>
+        <Stack direction="row" spacing={1.5} alignItems="flex-start">
+          <NextLink href={`/profile/${post.author.id}`} style={{ textDecoration: "none", flexShrink: 0 }}>
             <Avatar
               src={post.author.imageUrl || undefined}
               alt={post.author.name}
@@ -83,7 +102,7 @@ export default function CommunityPostCard({
             </Avatar>
           </NextLink>
           <Box sx={{ minWidth: 0, flex: 1 }}>
-            <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+            <Stack direction="row" spacing={0.75} alignItems="center" flexWrap="wrap" useFlexGap>
               <MuiLink
                 component={NextLink}
                 href={`/profile/${post.author.id}`}
@@ -94,6 +113,20 @@ export default function CommunityPostCard({
                   {post.author.name}
                 </Typography>
               </MuiLink>
+              {post.pinned ? (
+                <Tooltip title="Pinned post">
+                  <PushPin sx={{ fontSize: "0.95rem" }} color="primary" />
+                </Tooltip>
+              ) : null}
+              {canModerate ? (
+                <Chip
+                  label={post.status}
+                  size="small"
+                  color={STATUS_CHIP_COLOR[post.status] ?? "default"}
+                  variant="outlined"
+                  sx={{ fontSize: "0.65rem", height: 20 }}
+                />
+              ) : null}
             </Stack>
             <Typography variant="caption" color="text.secondary">
               {createdAt}
@@ -108,6 +141,7 @@ export default function CommunityPostCard({
                   color="error"
                   disabled={deleteDisabled}
                   onClick={() => onDelete(post.id)}
+                  sx={{ flexShrink: 0 }}
                 >
                   <Delete fontSize="small" />
                 </IconButton>
@@ -189,6 +223,50 @@ export default function CommunityPostCard({
               </Box>
             ))}
           </Box>
+        ) : null}
+
+        {canModerate && onModerate ? (
+          <>
+            <Divider />
+            <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap alignItems="center">
+              {post.status === "PENDING" ? (
+                <Tooltip title="Approve">
+                  <span>
+                    <IconButton size="small" color="success" disabled={moderateDisabled} onClick={() => onModerate(post.id, "approve")}>
+                      <CheckCircle fontSize="small" />
+                    </IconButton>
+                  </span>
+                </Tooltip>
+              ) : null}
+              {communityModerated && post.status !== "REJECTED" && post.status !== "DELETED" ? (
+                <Tooltip title="Reject">
+                  <span>
+                    <IconButton size="small" color="error" disabled={moderateDisabled} onClick={() => onModerate(post.id, "reject")}>
+                      <ThumbDown fontSize="small" />
+                    </IconButton>
+                  </span>
+                </Tooltip>
+              ) : null}
+              {post.status !== "DELETED" ? (
+                <Tooltip title={post.pinned ? "Unpin" : "Pin to top"}>
+                  <span>
+                    <IconButton size="small" color={post.pinned ? "primary" : "default"} disabled={moderateDisabled} onClick={() => onModerate(post.id, post.pinned ? "unpin" : "pin")}>
+                      {post.pinned ? <PushPin fontSize="small" /> : <PushPinOutlined fontSize="small" />}
+                    </IconButton>
+                  </span>
+                </Tooltip>
+              ) : null}
+              {post.status !== "DELETED" ? (
+                <Tooltip title="Remove post">
+                  <span>
+                    <IconButton size="small" color="error" disabled={moderateDisabled} onClick={() => onModerate(post.id, "remove")}>
+                      <Delete fontSize="small" />
+                    </IconButton>
+                  </span>
+                </Tooltip>
+              ) : null}
+            </Stack>
+          </>
         ) : null}
 
         <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>

--- a/src/components/events/community/CommunitySection.tsx
+++ b/src/components/events/community/CommunitySection.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { Alert, Box, Button, CircularProgress, Divider, Paper, Stack, Typography } from "@mui/material";
+import { Settings } from "@mui/icons-material";
+import NextLink from "next/link";
 import CommunityComposer from "./CommunityComposer";
 import CommunityPostCard from "./CommunityPostCard";
 import type { CommunityPostView, CommunityReactionKey } from "./types";
@@ -30,6 +32,7 @@ interface CommunitySectionProps {
   eventId: number;
   eventEnded: boolean;
   communityOpenAfterEnd: boolean;
+  communityModerated?: boolean;
   currentUserId?: string | null;
   canModerate?: boolean;
 }
@@ -38,6 +41,7 @@ export default function CommunitySection({
   eventId,
   eventEnded,
   communityOpenAfterEnd,
+  communityModerated = true,
   currentUserId,
   canModerate,
 }: CommunitySectionProps) {
@@ -46,6 +50,7 @@ export default function CommunitySection({
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
   const [actionPostId, setActionPostId] = useState<string | null>(null);
+  const [moderatingPostId, setModeratingPostId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const composerDisabledReason = useMemo(() => {
@@ -156,6 +161,49 @@ export default function CommunitySection({
     }
   };
 
+  const handleModerate = async (postId: string, action: "approve" | "reject" | "pin" | "unpin" | "remove") => {
+    setModeratingPostId(postId);
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/community/posts/${postId}/moderate`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action }),
+      });
+      const payload = (await response.json().catch(() => null)) as {
+        post?: { id: string; status: string; pinned: boolean };
+        action?: string;
+        error?: unknown;
+      } | null;
+
+      if (!response.ok) {
+        throw new Error(getErrorMessage(payload, "Moderation action failed"));
+      }
+
+      if (action === "remove") {
+        setPosts(current => current.filter(p => p.id !== postId));
+      } else if (payload?.post) {
+        const updated = payload.post;
+        setPosts(current =>
+          current.map(p =>
+            p.id !== postId
+              ? p
+              : {
+                  ...p,
+                  status: updated.status as CommunityPostView["status"],
+                  pinned: updated.pinned,
+                },
+          ),
+        );
+      }
+    } catch (moderateError) {
+      setError(moderateError instanceof Error ? moderateError.message : "Moderation action failed");
+    } finally {
+      setModeratingPostId(null);
+    }
+  };
+
   const handleDelete = async (postId: string) => {
     setActionPostId(postId);
     setError(null);
@@ -182,9 +230,28 @@ export default function CommunitySection({
     <Paper variant="outlined" sx={{ p: 3 }}>
       <Stack spacing={3}>
         <Box>
-          <Typography variant="h4" gutterBottom fontWeight="bold">
-            Community
-          </Typography>
+          <Stack
+            direction="row"
+            justifyContent="space-between"
+            alignItems={{ xs: "flex-start", sm: "center" }}
+            flexWrap="wrap"
+            gap={1}
+          >
+            <Typography variant="h4" fontWeight="bold">
+              Community
+            </Typography>
+            {canModerate ? (
+              <Button
+                component={NextLink}
+                href={`/admin/events/${eventId}/community`}
+                size="small"
+                variant="outlined"
+                startIcon={<Settings fontSize="small" />}
+              >
+                Manage community
+              </Button>
+            ) : null}
+          </Stack>
           {eventEnded ? (
             <Alert severity="info" sx={{ mt: 2 }}>
               This is the post-event community space for attendees and organizers.
@@ -215,9 +282,13 @@ export default function CommunitySection({
                 key={post.id}
                 post={post}
                 canDelete={Boolean(canModerate || post.authorId === currentUserId)}
+                canModerate={canModerate}
+                communityModerated={communityModerated}
                 deleteDisabled={!currentUserId || actionPostId === post.id}
+                moderateDisabled={Boolean(moderatingPostId)}
                 reactionDisabled={!currentUserId || Boolean(composerDisabledReason)}
                 onDelete={handleDelete}
+                onModerate={canModerate ? handleModerate : undefined}
                 onReact={handleReact}
               />
             ))}

--- a/src/lib/badges/badge.test.ts
+++ b/src/lib/badges/badge.test.ts
@@ -6,6 +6,14 @@ vi.mock("@/lib/user/profilePicture", () => ({
   refreshSignedUrls: vi.fn(async pictures => pictures),
 }));
 
+vi.mock("@/lib/prisma/prisma", () => ({
+  prisma: {
+    registration: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
 const attendee: BadgeAttendee = {
   id: "reg-1",
   registrationId: "reg-1",

--- a/src/types/schemas/community.ts
+++ b/src/types/schemas/community.ts
@@ -102,5 +102,19 @@ export const reactToCommunityPostSchema = z.object({
   reaction: z.enum(communityReactionSchemaValues),
 });
 
+export const moderateCommunityPostSchema = z.object({
+  action: z.enum(["approve", "reject", "remove", "pin", "unpin"]),
+  reason: z.string().trim().max(500).optional(),
+});
+
+export const bulkModerateCommunityPostsSchema = z.object({
+  eventId: z.number().int().positive(),
+  postIds: z.array(z.string().min(1)).min(1).max(100),
+  action: z.enum(["remove", "approve", "reject"]),
+  reason: z.string().trim().max(500).optional(),
+});
+
 export type CreateCommunityPostInput = z.infer<typeof createCommunityPostSchema>;
 export type CommunityFeedbackInput = z.infer<typeof communityFeedbackEntrySchema>;
+export type ModerateCommunityPostInput = z.infer<typeof moderateCommunityPostSchema>;
+export type BulkModerateCommunityPostsInput = z.infer<typeof bulkModerateCommunityPostsSchema>;


### PR DESCRIPTION
- POST /api/community/posts/[postId]/moderate — approve, reject, pin, unpin (atomic $transaction), remove (softDeletePost)
- POST /api/community/posts/bulk-moderate — batch approve/reject/$transaction, batch remove/serial softDeletePost; filters cross-event IDs
- GET /api/admin/event/[id]/community/posts — status filter, cursor pagination, default excludes DELETED
- GET /api/admin/event/[id]/community/logs — audit log with actor info, cursor pagination
- CommunityModerationPanel: Pending/All/Deleted/Audit Log tabs, bulk select, per-post approve/reject/pin/unpin/remove, reject dialog
- Admin page at /admin/events/[id]/community with auth guard
- CommunityPostCard: pin needle (public), quick-action bar (admins), status chip, mobile-safe layout
- CommunitySection: handleModerate, "Manage community" button (admins)
- PINNED/UNPINNED added to ModerationAction enum + migration
- 43 tests covering all new routes

## Summary

## Testing

<!-- ventry:auto-fixes:start -->
Fixes #37
<!-- ventry:auto-fixes:end -->
