### PR TITLE
feat(community): add comments, Giphy picker, GIF upload, and @mention…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,8 @@
         "@fullcalendar/interaction": "^6.1.15",
         "@fullcalendar/react": "^6.1.20",
         "@fullcalendar/timegrid": "^6.1.15",
+        "@giphy/js-fetch-api": "^5.8.0",
+        "@giphy/js-types": "^5.1.0",
         "@hookform/resolvers": "^5.2.2",
         "@mui/icons-material": "^7.3.4",
         "@mui/material": "^7.3.4",
@@ -1748,6 +1750,32 @@
       },
       "peerDependencies": {
         "@fullcalendar/core": "~6.1.20"
+      }
+    },
+    "node_modules/@giphy/js-fetch-api": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@giphy/js-fetch-api/-/js-fetch-api-5.8.0.tgz",
+      "integrity": "sha512-DWdNauYaBSLPeAe/O+uzXtPIoUvmSnYV8Q49p+cPjEQ7Ncj1mDg1fuSKyl0OmPxCm6fzGJ4kuJjsWzyWn9ubbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@giphy/js-types": "*",
+        "@giphy/js-util": "*"
+      }
+    },
+    "node_modules/@giphy/js-types": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@giphy/js-types/-/js-types-5.1.0.tgz",
+      "integrity": "sha512-BZYCDtYNRR7cUWkbDLB4wmm3qmWMsVCQdUiBNOfmZ3yAazCgygKJoDI/5Rq4CK5MBaOc5LVdF8viC2WtoBdaPA==",
+      "license": "MIT"
+    },
+    "node_modules/@giphy/js-util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@giphy/js-util/-/js-util-5.2.0.tgz",
+      "integrity": "sha512-Qt7pGh2cqiNmXLeWAgb459wK8+BuMLtIxTfg4ZksnPHPsLthiHT9hhzs2QhqUh7Pp/HOq+Cbv2etGDfnq+xiKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@giphy/js-types": "*",
+        "uuid": "^9.0.0"
       }
     },
     "node_modules/@hexagon/base64": {
@@ -12033,6 +12061,20 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/valibot": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "@fullcalendar/interaction": "^6.1.15",
     "@fullcalendar/react": "^6.1.20",
     "@fullcalendar/timegrid": "^6.1.15",
+    "@giphy/js-fetch-api": "^5.8.0",
+    "@giphy/js-types": "^5.1.0",
     "@hookform/resolvers": "^5.2.2",
     "@mui/icons-material": "^7.3.4",
     "@mui/material": "^7.3.4",

--- a/prisma/migrations/20260618115536_add_community_comments/migration.sql
+++ b/prisma/migrations/20260618115536_add_community_comments/migration.sql
@@ -1,0 +1,31 @@
+-- AlterTable
+ALTER TABLE "Event" ADD COLUMN     "communityModerateComments" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateTable
+CREATE TABLE "CommunityComment" (
+    "id" TEXT NOT NULL,
+    "postId" TEXT NOT NULL,
+    "authorId" TEXT NOT NULL,
+    "content" TEXT,
+    "imageUrls" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "gifUrl" TEXT,
+    "mentionedUserIds" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "status" "PostStatus" NOT NULL DEFAULT 'PENDING',
+    "deletedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "CommunityComment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "CommunityComment_postId_status_createdAt_idx" ON "CommunityComment"("postId", "status", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "CommunityComment_authorId_createdAt_idx" ON "CommunityComment"("authorId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "CommunityComment" ADD CONSTRAINT "CommunityComment_postId_fkey" FOREIGN KEY ("postId") REFERENCES "CommunityPost"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CommunityComment" ADD CONSTRAINT "CommunityComment_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,6 +55,7 @@ model User {
   sessions             Session[]
   twofactors           TwoFactor[]
   communityPosts       CommunityPost[]
+  communityComments    CommunityComment[]
   postReactions        PostReaction[]
   postModerationLogs   PostModerationLog[] @relation("UserPostModerationLogs")
 
@@ -147,6 +148,7 @@ model Event {
   communityEnabled    Boolean         @default(false)
   communityOpenAfterEnd Boolean       @default(true)
   communityModerated  Boolean         @default(true)
+  communityModerateComments Boolean   @default(false)
   communityAttendeesOnly Boolean      @default(true)
   badgeTemplates      BadgeTemplate[]
   owner               Admin?          @relation(fields: [ownerId], references: [id])
@@ -181,8 +183,28 @@ model CommunityPost {
   author         User                @relation(fields: [authorId], references: [id], onDelete: Cascade)
   reactions      PostReaction[]
   moderationLogs PostModerationLog[]
+  comments       CommunityComment[]
 
   @@index([eventId, status, pinned, createdAt])
+  @@index([authorId, createdAt])
+}
+
+model CommunityComment {
+  id               String        @id @default(cuid())
+  postId           String
+  authorId         String
+  content          String?
+  imageUrls        String[]      @default([])
+  gifUrl           String?
+  mentionedUserIds String[]      @default([])
+  status           PostStatus    @default(PENDING)
+  deletedAt        DateTime?
+  createdAt        DateTime      @default(now())
+  updatedAt        DateTime      @updatedAt
+  post             CommunityPost @relation(fields: [postId], references: [id], onDelete: Cascade)
+  author           User          @relation(fields: [authorId], references: [id], onDelete: Cascade)
+
+  @@index([postId, status, createdAt])
   @@index([authorId, createdAt])
 }
 

--- a/src/__tests__/api/community-comment-delete.test.ts
+++ b/src/__tests__/api/community-comment-delete.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { DELETE } from "@/app/api/community/comments/[commentId]/route";
+import { NextRequest } from "next/server";
+import { PostStatus } from "@/generated/prisma";
+
+vi.mock("@/lib/prisma/prisma", () => ({
+  prisma: {
+    communityComment: { findUnique: vi.fn(), update: vi.fn() },
+    user: { findUnique: vi.fn() },
+  },
+}));
+
+import { prisma } from "@/lib/prisma/prisma";
+
+const getSessionMock = vi.fn();
+vi.mock("@/lib/auth/session", () => ({ getSession: () => getSessionMock() }));
+
+type P = {
+  communityComment: { findUnique: ReturnType<typeof vi.fn>; update: ReturnType<typeof vi.fn> };
+  user: { findUnique: ReturnType<typeof vi.fn> };
+};
+const p = prisma as unknown as P;
+
+const COMMENT_ID = "comment-1";
+const AUTHOR_ID = "user-author";
+const OTHER_ID = "user-other";
+const EVENT_OWNER_ADMIN_ID = "admin-event-owner";
+
+const mockComment = {
+  id: COMMENT_ID,
+  authorId: AUTHOR_ID,
+  deletedAt: null,
+  post: { event: { ownerId: EVENT_OWNER_ADMIN_ID } },
+};
+
+const PARAMS = { params: Promise.resolve({ commentId: COMMENT_ID }) };
+
+function makeReq(): NextRequest {
+  return new NextRequest(`http://localhost/api/community/comments/${COMMENT_ID}`, { method: "DELETE" });
+}
+
+describe("DELETE /api/community/comments/[commentId]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    p.communityComment.update.mockResolvedValue({});
+  });
+
+  it("returns 401 without session", async () => {
+    getSessionMock.mockReturnValue(null);
+
+    const res = await DELETE(makeReq(), PARAMS);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when comment does not exist", async () => {
+    getSessionMock.mockReturnValue({ user: { id: AUTHOR_ID } });
+    p.communityComment.findUnique.mockResolvedValue(null);
+
+    const res = await DELETE(makeReq(), PARAMS);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 when comment is already soft-deleted", async () => {
+    getSessionMock.mockReturnValue({ user: { id: AUTHOR_ID } });
+    p.communityComment.findUnique.mockResolvedValue({ ...mockComment, deletedAt: new Date() });
+
+    const res = await DELETE(makeReq(), PARAMS);
+    expect(res.status).toBe(404);
+  });
+
+  it("allows comment author to delete their own comment", async () => {
+    getSessionMock.mockReturnValue({ user: { id: AUTHOR_ID } });
+    p.communityComment.findUnique.mockResolvedValue(mockComment);
+    p.user.findUnique.mockResolvedValue({ id: AUTHOR_ID, isAdmin: false, adminProfile: null });
+
+    const res = await DELETE(makeReq(), PARAMS);
+    const body = await res.json() as { deleted: boolean };
+
+    expect(res.status).toBe(200);
+    expect(body.deleted).toBe(true);
+    expect(p.communityComment.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          status: PostStatus.DELETED,
+          content: null,
+          imageUrls: [],
+          gifUrl: null,
+          deletedAt: expect.any(Date),
+        }),
+      }),
+    );
+  });
+
+  it("returns 403 when non-author without admin rights tries to delete", async () => {
+    getSessionMock.mockReturnValue({ user: { id: OTHER_ID } });
+    p.communityComment.findUnique.mockResolvedValue(mockComment);
+    p.user.findUnique.mockResolvedValue({ id: OTHER_ID, isAdmin: false, adminProfile: null });
+
+    const res = await DELETE(makeReq(), PARAMS);
+    expect(res.status).toBe(403);
+  });
+
+  it("allows platform admin to delete any comment", async () => {
+    getSessionMock.mockReturnValue({ user: { id: OTHER_ID } });
+    p.communityComment.findUnique.mockResolvedValue(mockComment);
+    p.user.findUnique.mockResolvedValue({ id: OTHER_ID, isAdmin: true, adminProfile: { id: "admin-profile-id" } });
+
+    const res = await DELETE(makeReq(), PARAMS);
+    expect(res.status).toBe(200);
+  });
+
+  it("allows event owner to delete comments in their event", async () => {
+    getSessionMock.mockReturnValue({ user: { id: OTHER_ID } });
+    // mockComment has post.event.ownerId = EVENT_OWNER_ADMIN_ID
+    p.communityComment.findUnique.mockResolvedValue(mockComment);
+    // actor.adminId matches ownerId
+    p.user.findUnique.mockResolvedValue({ id: OTHER_ID, isAdmin: false, adminProfile: { id: EVENT_OWNER_ADMIN_ID } });
+
+    const res = await DELETE(makeReq(), PARAMS);
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/__tests__/api/community-comments.test.ts
+++ b/src/__tests__/api/community-comments.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { GET, POST } from "@/app/api/community/posts/[postId]/comments/route";
+import { NextRequest } from "next/server";
+import { PostStatus } from "@/generated/prisma";
+
+vi.mock("@/lib/prisma/prisma", () => ({
+  prisma: {
+    communityPost: { findUnique: vi.fn() },
+    event: { findUnique: vi.fn() },
+    user: { findUnique: vi.fn(), findMany: vi.fn() },
+    communityComment: { findMany: vi.fn(), create: vi.fn() },
+    registration: { findFirst: vi.fn() },
+  },
+}));
+
+import { prisma } from "@/lib/prisma/prisma";
+
+const getSessionMock = vi.fn();
+vi.mock("@/lib/auth/session", () => ({ getSession: () => getSessionMock() }));
+
+type P = {
+  communityPost: { findUnique: ReturnType<typeof vi.fn> };
+  event: { findUnique: ReturnType<typeof vi.fn> };
+  user: { findUnique: ReturnType<typeof vi.fn>; findMany: ReturnType<typeof vi.fn> };
+  communityComment: { findMany: ReturnType<typeof vi.fn>; create: ReturnType<typeof vi.fn> };
+  registration: { findFirst: ReturnType<typeof vi.fn> };
+};
+const p = prisma as unknown as P;
+
+const POST_ID = "post-abc";
+const EVENT_ID = 42;
+const USER_ID = "user-1";
+const COMMENT_ID = "comment-xyz";
+
+const mockEvent = {
+  id: EVENT_ID,
+  ownerId: null,
+  endDate: new Date(Date.now() + 86_400_000),
+  communityEnabled: true,
+  communityOpenAfterEnd: true,
+  communityModerated: false,
+  communityModerateComments: false,
+  communityAttendeesOnly: false,
+};
+
+const mockCommentRow = {
+  id: COMMENT_ID,
+  postId: POST_ID,
+  authorId: USER_ID,
+  content: "Hello @John_Doe!",
+  imageUrls: [],
+  gifUrl: null,
+  mentionedUserIds: ["user-john"],
+  status: PostStatus.APPROVED,
+  deletedAt: null,
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+  updatedAt: new Date("2026-01-01T00:00:00Z"),
+  author: { id: USER_ID, name: "Test User", image: null, profilePictures: [] },
+};
+
+const PARAMS = { params: Promise.resolve({ postId: POST_ID }) };
+
+function req(url: string, method = "GET", body?: unknown): NextRequest {
+  return new NextRequest(url, {
+    method,
+    ...(body ? { headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) } : {}),
+  });
+}
+
+// ─── GET ──────────────────────────────────────────────────────────────────────
+
+describe("GET /api/community/posts/[postId]/comments", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    p.communityPost.findUnique.mockResolvedValue({ id: POST_ID, eventId: EVENT_ID, status: PostStatus.APPROVED });
+    p.event.findUnique.mockResolvedValue(mockEvent);
+  });
+
+  it("returns 404 when post does not exist", async () => {
+    p.communityPost.findUnique.mockResolvedValue(null);
+
+    const res = await GET(req(`http://localhost/comments`), PARAMS);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when community is disabled", async () => {
+    p.event.findUnique.mockResolvedValue({ ...mockEvent, communityEnabled: false });
+    p.communityComment.findMany.mockResolvedValue([]);
+    p.user.findMany.mockResolvedValue([]);
+
+    const res = await GET(req(`http://localhost/comments`), PARAMS);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns comments with mentionedUsers resolved from IDs", async () => {
+    p.communityComment.findMany.mockResolvedValue([mockCommentRow]);
+    p.user.findMany.mockResolvedValue([{ id: "user-john", name: "John Doe" }]);
+
+    const res = await GET(req(`http://localhost/comments`), PARAMS);
+    const body = await res.json() as { comments: { mentionedUsers: { id: string; name: string }[] }[] };
+
+    expect(res.status).toBe(200);
+    expect(body.comments).toHaveLength(1);
+    expect(body.comments[0].mentionedUsers).toEqual([{ id: "user-john", name: "John Doe" }]);
+  });
+
+  it("returns empty mentionedUsers for comments with no mentions", async () => {
+    const noMentionRow = { ...mockCommentRow, content: "plain text", mentionedUserIds: [] };
+    p.communityComment.findMany.mockResolvedValue([noMentionRow]);
+    p.user.findMany.mockResolvedValue([]);
+
+    const res = await GET(req(`http://localhost/comments`), PARAMS);
+    const body = await res.json() as { comments: { mentionedUsers: unknown[] }[] };
+
+    expect(res.status).toBe(200);
+    expect(body.comments[0].mentionedUsers).toEqual([]);
+  });
+
+  it("sets nextCursor when more items exist beyond limit", async () => {
+    const comments = Array.from({ length: 6 }, (_, i) => ({
+      ...mockCommentRow, id: `c-${i}`, mentionedUserIds: [],
+    }));
+    p.communityComment.findMany.mockResolvedValue(comments);
+    p.user.findMany.mockResolvedValue([]);
+
+    const res = await GET(req(`http://localhost/comments?limit=5`), PARAMS);
+    const body = await res.json() as { comments: unknown[]; nextCursor: string | null };
+
+    expect(body.comments).toHaveLength(5);
+    expect(body.nextCursor).toBe("c-4");
+  });
+
+  it("sets nextCursor to null when no more items", async () => {
+    p.communityComment.findMany.mockResolvedValue([{ ...mockCommentRow, mentionedUserIds: [] }]);
+    p.user.findMany.mockResolvedValue([]);
+
+    const res = await GET(req(`http://localhost/comments?limit=5`), PARAMS);
+    const body = await res.json() as { nextCursor: string | null };
+
+    expect(body.nextCursor).toBeNull();
+  });
+});
+
+// ─── POST ─────────────────────────────────────────────────────────────────────
+
+describe("POST /api/community/posts/[postId]/comments", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getSessionMock.mockReturnValue({ user: { id: USER_ID } });
+    p.communityPost.findUnique.mockResolvedValue({ id: POST_ID, eventId: EVENT_ID, status: PostStatus.APPROVED });
+    p.user.findUnique.mockResolvedValue({ id: USER_ID, isAdmin: false, adminProfile: null });
+    p.event.findUnique.mockResolvedValue(mockEvent);
+    p.user.findMany.mockResolvedValue([]);
+  });
+
+  it("returns 401 without session", async () => {
+    getSessionMock.mockReturnValue(null);
+
+    const res = await POST(req(`http://localhost/comments`, "POST", { content: "hi" }), PARAMS);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 422 when comment is empty", async () => {
+    const res = await POST(req(`http://localhost/comments`, "POST", {}), PARAMS);
+    expect(res.status).toBe(422);
+  });
+
+  it("creates comment and returns 201", async () => {
+    const created = { ...mockCommentRow, content: "hi", mentionedUserIds: [] };
+    p.communityComment.create.mockResolvedValue(created);
+
+    const res = await POST(req(`http://localhost/comments`, "POST", { content: "hi" }), PARAMS);
+    const body = await res.json() as { comment: { id: string }; pending: boolean };
+
+    expect(res.status).toBe(201);
+    expect(body.comment.id).toBe(COMMENT_ID);
+    expect(body.pending).toBe(false);
+  });
+
+  it("resolves @name tokens and stores user IDs in mentionedUserIds", async () => {
+    const mentioned = { id: "user-john", name: "John Doe" };
+    // First findMany: resolve name → ID. Second findMany: build mention map.
+    p.user.findMany.mockResolvedValueOnce([mentioned]).mockResolvedValueOnce([mentioned]);
+    const created = { ...mockCommentRow, content: "Hey @John_Doe", mentionedUserIds: ["user-john"] };
+    p.communityComment.create.mockResolvedValue(created);
+
+    const res = await POST(
+      req(`http://localhost/comments`, "POST", { content: "Hey @John_Doe" }),
+      PARAMS,
+    );
+    const body = await res.json() as { comment: { mentionedUsers: { id: string }[] } };
+
+    expect(res.status).toBe(201);
+    expect(body.comment.mentionedUsers).toEqual([{ id: "user-john", name: "John Doe" }]);
+    expect(p.communityComment.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ mentionedUserIds: ["user-john"] }),
+      }),
+    );
+  });
+
+  it("stores comment as PENDING when communityModerated + communityModerateComments", async () => {
+    p.event.findUnique.mockResolvedValue({ ...mockEvent, communityModerated: true, communityModerateComments: true });
+    p.communityComment.create.mockResolvedValue({ ...mockCommentRow, status: PostStatus.PENDING, mentionedUserIds: [] });
+
+    const res = await POST(req(`http://localhost/comments`, "POST", { content: "hi" }), PARAMS);
+    const body = await res.json() as { pending: boolean };
+
+    expect(res.status).toBe(201);
+    expect(body.pending).toBe(true);
+    expect(p.communityComment.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ status: PostStatus.PENDING }) }),
+    );
+  });
+
+  it("stores comment as APPROVED when post moderation on but comment moderation off", async () => {
+    p.event.findUnique.mockResolvedValue({ ...mockEvent, communityModerated: true, communityModerateComments: false });
+    p.communityComment.create.mockResolvedValue({ ...mockCommentRow, status: PostStatus.APPROVED, mentionedUserIds: [] });
+
+    await POST(req(`http://localhost/comments`, "POST", { content: "hi" }), PARAMS);
+
+    expect(p.communityComment.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ status: PostStatus.APPROVED }) }),
+    );
+  });
+
+  it("returns 404 when post does not exist", async () => {
+    p.communityPost.findUnique.mockResolvedValue(null);
+
+    const res = await POST(req(`http://localhost/comments`, "POST", { content: "hi" }), PARAMS);
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/__tests__/api/community-mention-suggestions.test.ts
+++ b/src/__tests__/api/community-mention-suggestions.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { GET } from "@/app/api/community/events/[eventId]/mention-suggestions/route";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/prisma/prisma", () => ({
+  prisma: {
+    user: { findMany: vi.fn() },
+  },
+}));
+
+import { prisma } from "@/lib/prisma/prisma";
+
+const getSessionMock = vi.fn();
+vi.mock("@/lib/auth/session", () => ({ getSession: () => getSessionMock() }));
+
+type P = { user: { findMany: ReturnType<typeof vi.fn> } };
+const p = prisma as unknown as P;
+
+const EVENT_ID = 7;
+const PARAMS = { params: Promise.resolve({ eventId: String(EVENT_ID) }) };
+
+function makeReq(q?: string): NextRequest {
+  const url = q
+    ? `http://localhost/api/community/events/${EVENT_ID}/mention-suggestions?q=${encodeURIComponent(q)}`
+    : `http://localhost/api/community/events/${EVENT_ID}/mention-suggestions`;
+  return new NextRequest(url);
+}
+
+describe("GET /api/community/events/[eventId]/mention-suggestions", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 401 without session", async () => {
+    getSessionMock.mockReturnValue(null);
+
+    const res = await GET(makeReq(), PARAMS);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for non-numeric eventId", async () => {
+    getSessionMock.mockReturnValue({ user: { id: "u1" } });
+
+    const res = await GET(
+      makeReq(),
+      { params: Promise.resolve({ eventId: "not-a-number" }) },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns matching users filtered by name prefix", async () => {
+    getSessionMock.mockReturnValue({ user: { id: "u1" } });
+    p.user.findMany.mockResolvedValue([
+      { id: "u-alice", name: "Alice Smith" },
+      { id: "u-alex", name: "Alex Jones" },
+    ]);
+
+    const res = await GET(makeReq("al"), PARAMS);
+    const body = await res.json() as { users: { id: string; name: string }[] };
+
+    expect(res.status).toBe(200);
+    expect(body.users).toHaveLength(2);
+    expect(body.users[0].name).toBe("Alice Smith");
+
+    // Query must be forwarded (spaces decoded from underscores)
+    expect(p.user.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          name: { contains: "al", mode: "insensitive" },
+        }),
+      }),
+    );
+  });
+
+  it("searches without name filter when query is empty", async () => {
+    getSessionMock.mockReturnValue({ user: { id: "u1" } });
+    p.user.findMany.mockResolvedValue([{ id: "u-bob", name: "Bob" }]);
+
+    const res = await GET(makeReq(""), PARAMS);
+    const body = await res.json() as { users: { id: string }[] };
+
+    expect(res.status).toBe(200);
+    expect(body.users).toHaveLength(1);
+    // No `name` key in where when query empty
+    expect(p.user.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.not.objectContaining({ name: expect.anything() }),
+      }),
+    );
+  });
+
+  it("converts underscores to spaces before querying", async () => {
+    getSessionMock.mockReturnValue({ user: { id: "u1" } });
+    p.user.findMany.mockResolvedValue([]);
+
+    await GET(makeReq("John_Doe"), PARAMS);
+
+    expect(p.user.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          name: { contains: "John Doe", mode: "insensitive" },
+        }),
+      }),
+    );
+  });
+
+  it("filters by eventId in OR conditions", async () => {
+    getSessionMock.mockReturnValue({ user: { id: "u1" } });
+    p.user.findMany.mockResolvedValue([]);
+
+    await GET(makeReq("x"), PARAMS);
+
+    const call = p.user.findMany.mock.calls[0][0] as { where: { OR: unknown[] } };
+    expect(call.where.OR).toBeDefined();
+    // Each branch should reference the event id
+    const branches = JSON.stringify(call.where.OR);
+    expect(branches).toContain(String(EVENT_ID));
+  });
+
+  it("omits users with null names from results", async () => {
+    getSessionMock.mockReturnValue({ user: { id: "u1" } });
+    p.user.findMany.mockResolvedValue([
+      { id: "u-named", name: "Alice" },
+      { id: "u-noname", name: null },
+    ]);
+
+    const res = await GET(makeReq("a"), PARAMS);
+    const body = await res.json() as { users: { id: string }[] };
+
+    expect(body.users).toHaveLength(1);
+    expect(body.users[0].id).toBe("u-named");
+  });
+});

--- a/src/__tests__/lib/community-server.test.ts
+++ b/src/__tests__/lib/community-server.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PostStatus, CommunityPostType } from "@/generated/prisma";
+
+vi.mock("@/lib/prisma/prisma", () => ({
+  prisma: {
+    user: { findMany: vi.fn() },
+  },
+}));
+
+import { prisma } from "@/lib/prisma/prisma";
+import { buildMentionMapForPosts, serializeCommunityPost } from "@/lib/community/server";
+import type { CommunityPostWithInclude } from "@/lib/community/server";
+
+type P = { user: { findMany: ReturnType<typeof vi.fn> } };
+const p = prisma as unknown as P;
+
+// ─── buildMentionMapForPosts ───────────────────────────────────────────────────
+
+describe("buildMentionMapForPosts", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns empty map when posts have no comments", async () => {
+    const result = await buildMentionMapForPosts([]);
+    expect(result.size).toBe(0);
+    expect(p.user.findMany).not.toHaveBeenCalled();
+  });
+
+  it("returns empty map when all comments have no mentionedUserIds", async () => {
+    const result = await buildMentionMapForPosts([{ comments: [{ mentionedUserIds: [] }] }]);
+    expect(result.size).toBe(0);
+    expect(p.user.findMany).not.toHaveBeenCalled();
+  });
+
+  it("fetches users for all mentionedUserIds across posts and returns map", async () => {
+    p.user.findMany.mockResolvedValue([
+      { id: "u1", name: "Alice" },
+      { id: "u2", name: "Bob" },
+    ]);
+
+    const result = await buildMentionMapForPosts([
+      { comments: [{ mentionedUserIds: ["u1"] }, { mentionedUserIds: ["u2"] }] },
+      { comments: [{ mentionedUserIds: ["u1"] }] }, // duplicate u1
+    ]);
+
+    expect(result.size).toBe(2);
+    expect(result.get("u1")).toEqual({ id: "u1", name: "Alice" });
+    expect(result.get("u2")).toEqual({ id: "u2", name: "Bob" });
+    // Deduplicates: only one DB call with unique IDs
+    expect(p.user.findMany).toHaveBeenCalledTimes(1);
+    expect(p.user.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: { in: expect.arrayContaining(["u1", "u2"]) } } }),
+    );
+    // Passed array must not contain duplicates
+    const call = p.user.findMany.mock.calls[0][0] as { where: { id: { in: string[] } } };
+    expect(call.where.id.in).toHaveLength(2);
+  });
+
+  it("uses 'User' fallback name when DB returns null name", async () => {
+    p.user.findMany.mockResolvedValue([{ id: "u1", name: null }]);
+
+    const result = await buildMentionMapForPosts([{ comments: [{ mentionedUserIds: ["u1"] }] }]);
+    expect(result.get("u1")).toEqual({ id: "u1", name: "User" });
+  });
+});
+
+// ─── serializeCommunityPost mention pass-through ──────────────────────────────
+
+function makePost(comments: { mentionedUserIds: string[] }[]): CommunityPostWithInclude {
+  const base = {
+    id: "post-1",
+    eventId: 1,
+    authorId: "author-1",
+    type: CommunityPostType.TEXT,
+    tags: [],
+    content: "content",
+    imageUrls: [],
+    linkUrl: null,
+    feedbackRating: null,
+    feedbackType: null,
+    feedbackEntries: [],
+    muxAssetId: null,
+    muxPlaybackId: null,
+    status: PostStatus.APPROVED,
+    pinned: false,
+    createdAt: new Date("2026-01-01"),
+    updatedAt: new Date("2026-01-01"),
+    deletedAt: null,
+    author: {
+      id: "author-1",
+      name: "Post Author",
+      image: null,
+      profilePictures: [],
+    },
+    reactions: [],
+    _count: { comments: comments.length },
+    comments: comments.map((c, i) => ({
+      id: `c-${i}`,
+      postId: "post-1",
+      authorId: "user-x",
+      content: "reply",
+      imageUrls: [],
+      gifUrl: null,
+      status: PostStatus.APPROVED,
+      deletedAt: null,
+      createdAt: new Date("2026-01-01"),
+      updatedAt: new Date("2026-01-01"),
+      mentionedUserIds: c.mentionedUserIds,
+      author: { id: "user-x", name: "Commenter", image: null, profilePictures: [] },
+    })),
+  };
+  return base as unknown as CommunityPostWithInclude;
+}
+
+describe("serializeCommunityPost — mention pass-through to preloaded comments", () => {
+  it("passes mentionedUsersById to preloaded comment serialization", () => {
+    const mentionMap = new Map([["u-alice", { id: "u-alice", name: "Alice" }]]);
+    const post = makePost([{ mentionedUserIds: ["u-alice"] }]);
+
+    const result = serializeCommunityPost(post, null, mentionMap);
+
+    expect(result.comments[0].mentionedUsers).toEqual([{ id: "u-alice", name: "Alice" }]);
+  });
+
+  it("returns empty mentionedUsers when no map provided", () => {
+    const post = makePost([{ mentionedUserIds: ["u-alice"] }]);
+
+    const result = serializeCommunityPost(post, null);
+
+    expect(result.comments[0].mentionedUsers).toEqual([]);
+  });
+
+  it("skips mention IDs not present in the map", () => {
+    const mentionMap = new Map([["u-alice", { id: "u-alice", name: "Alice" }]]);
+    const post = makePost([{ mentionedUserIds: ["u-alice", "u-unknown"] }]);
+
+    const result = serializeCommunityPost(post, null, mentionMap);
+
+    expect(result.comments[0].mentionedUsers).toEqual([{ id: "u-alice", name: "Alice" }]);
+  });
+
+  it("includes commentCount from _count.comments", () => {
+    const post = makePost([{ mentionedUserIds: [] }, { mentionedUserIds: [] }]);
+
+    const result = serializeCommunityPost(post, null, new Map());
+
+    expect(result.commentCount).toBe(2);
+  });
+});

--- a/src/app/api/admin/event/[id]/community/posts/route.test.ts
+++ b/src/app/api/admin/event/[id]/community/posts/route.test.ts
@@ -18,10 +18,15 @@ vi.mock("@/lib/auth/event-admin", () => ({
 vi.mock("@/lib/community/server", () => ({
   communityPostInclude: {},
   serializeCommunityPost: vi.fn((p: { id: string }) => ({ id: p.id, serialized: true })),
+  buildMentionMapForPosts: vi.fn(() => Promise.resolve(new Map([["u1", { id: "u1", name: "Alice" }]]))),
 }));
 
 import * as postsRoute from "./route";
 import { checkEventAdminAuth } from "@/lib/auth/event-admin";
+import { buildMentionMapForPosts, serializeCommunityPost } from "@/lib/community/server";
+
+const mockedBuildMentionMap = buildMentionMapForPosts as unknown as ReturnType<typeof vi.fn>;
+const mockedSerialize = serializeCommunityPost as unknown as ReturnType<typeof vi.fn>;
 
 const mockedCheckEventAdminAuth = checkEventAdminAuth as unknown as ReturnType<typeof vi.fn>;
 const mockedFindMany = prismaMock.communityPost.findMany as unknown as ReturnType<typeof vi.fn>;
@@ -201,6 +206,76 @@ describe("GET /api/admin/event/[id]/community/posts", () => {
     expect(mockedFindMany).toHaveBeenCalledWith(
       expect.objectContaining({
         take: 51,
+      }),
+    );
+  });
+
+  it("calls buildMentionMapForPosts with the page of posts", async () => {
+    const posts = makePosts(3);
+    mockedFindMany.mockResolvedValue(posts);
+
+    await postsRoute.GET(
+      getRequest("7"),
+      { params: Promise.resolve({ id: "7" }) },
+    );
+
+    expect(mockedBuildMentionMap).toHaveBeenCalledWith(posts);
+  });
+
+  it("passes mention map from buildMentionMapForPosts to serializeCommunityPost", async () => {
+    const mentionMap = new Map([["u-x", { id: "u-x", name: "Xavier" }]]);
+    mockedBuildMentionMap.mockResolvedValueOnce(mentionMap);
+    mockedFindMany.mockResolvedValue(makePosts(2));
+
+    await postsRoute.GET(
+      getRequest("7"),
+      { params: Promise.resolve({ id: "7" }) },
+    );
+
+    for (const call of mockedSerialize.mock.calls) {
+      expect(call[2]).toBe(mentionMap);
+    }
+  });
+
+  it("serializes each post in the page", async () => {
+    mockedFindMany.mockResolvedValue(makePosts(3));
+
+    const response = await postsRoute.GET(
+      getRequest("7"),
+      { params: Promise.resolve({ id: "7" }) },
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockedSerialize).toHaveBeenCalledTimes(3);
+    const body = await response.json() as { posts: { id: string; serialized: boolean }[] };
+    expect(body.posts.every(p => p.serialized)).toBe(true);
+  });
+
+  it("returns empty posts array when event has no posts", async () => {
+    mockedFindMany.mockResolvedValue([]);
+
+    const response = await postsRoute.GET(
+      getRequest("7"),
+      { params: Promise.resolve({ id: "7" }) },
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as { posts: unknown[]; nextCursor: unknown };
+    expect(body.posts).toHaveLength(0);
+    expect(body.nextCursor).toBeNull();
+  });
+
+  it("filters posts by eventId", async () => {
+    mockedFindMany.mockResolvedValue([]);
+
+    await postsRoute.GET(
+      getRequest("42"),
+      { params: Promise.resolve({ id: "42" }) },
+    );
+
+    expect(mockedFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ eventId: 42 }),
       }),
     );
   });

--- a/src/app/api/admin/event/[id]/community/posts/route.ts
+++ b/src/app/api/admin/event/[id]/community/posts/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { PostStatus } from "@/generated/prisma";
 import { checkEventAdminAuth } from "@/lib/auth/event-admin";
-import { communityPostInclude, serializeCommunityPost } from "@/lib/community/server";
+import { buildMentionMapForPosts, communityPostInclude, serializeCommunityPost } from "@/lib/community/server";
 import { prisma } from "@/lib/prisma/prisma";
 
 const VALID_STATUSES = Object.values(PostStatus);
@@ -41,8 +41,10 @@ export async function GET(
   const hasMore = posts.length > limit;
   const page = hasMore ? posts.slice(0, limit) : posts;
 
+  const mentionedUsersById = await buildMentionMapForPosts(page);
+
   return NextResponse.json({
-    posts: page.map(p => serializeCommunityPost(p, auth.user?.id)),
+    posts: page.map(p => serializeCommunityPost(p, auth.user?.id, mentionedUsersById)),
     nextCursor: hasMore ? (page[page.length - 1]?.id ?? null) : null,
   });
 }

--- a/src/app/api/admin/event/route.ts
+++ b/src/app/api/admin/event/route.ts
@@ -77,6 +77,7 @@ function buildCreateEventArgs(
             communityEnabled: validatedData.communityEnabled ?? false,
             communityOpenAfterEnd: validatedData.communityOpenAfterEnd ?? true,
             communityModerated: validatedData.communityModerated ?? true,
+            communityModerateComments: validatedData.communityModerateComments ?? false,
             communityAttendeesOnly: validatedData.communityAttendeesOnly ?? true,
         },
         include: {

--- a/src/app/api/community/comments/[commentId]/route.ts
+++ b/src/app/api/community/comments/[commentId]/route.ts
@@ -1,0 +1,78 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { PostStatus } from "@/generated/prisma";
+import {
+  CommunityError,
+  isEventOwner,
+  loadCommunityActor,
+} from "@/lib/community/server";
+import { getSession } from "@/lib/auth/session";
+import { prisma } from "@/lib/prisma/prisma";
+
+function toErrorResponse(error: unknown, logMessage: string) {
+  if (error instanceof CommunityError) {
+    return NextResponse.json({ error: error.message }, { status: error.status });
+  }
+
+  console.error(logMessage, error);
+  return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+}
+
+export async function DELETE(req: NextRequest, { params }: { params: Promise<{ commentId: string }> }) {
+  try {
+    const { commentId } = await params;
+
+    const session = await getSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const comment = await prisma.communityComment.findUnique({
+      where: { id: commentId },
+      select: {
+        id: true,
+        authorId: true,
+        deletedAt: true,
+        post: {
+          select: {
+            event: {
+              select: { ownerId: true },
+            },
+          },
+        },
+      },
+    });
+
+    if (!comment || comment.deletedAt) {
+      return NextResponse.json({ error: "Comment not found" }, { status: 404 });
+    }
+
+    const actor = await loadCommunityActor(session.user.id);
+    if (!actor) {
+      return NextResponse.json({ error: "User not found" }, { status: 403 });
+    }
+
+    const canDelete =
+      comment.authorId === actor.id ||
+      actor.isAdmin ||
+      isEventOwner(actor, comment.post.event);
+
+    if (!canDelete) {
+      return NextResponse.json({ error: "You cannot delete this comment" }, { status: 403 });
+    }
+
+    await prisma.communityComment.update({
+      where: { id: commentId },
+      data: {
+        status: PostStatus.DELETED,
+        content: null,
+        imageUrls: [],
+        gifUrl: null,
+        deletedAt: new Date(),
+      },
+    });
+
+    return NextResponse.json({ deleted: true }, { status: 200 });
+  } catch (error) {
+    return toErrorResponse(error, "Error deleting community comment:");
+  }
+}

--- a/src/app/api/community/events/[eventId]/mention-suggestions/route.ts
+++ b/src/app/api/community/events/[eventId]/mention-suggestions/route.ts
@@ -1,0 +1,50 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { PostStatus, RegistrationStatus } from "@/generated/prisma";
+import { getSession } from "@/lib/auth/session";
+import { prisma } from "@/lib/prisma/prisma";
+
+export async function GET(req: NextRequest, { params }: { params: Promise<{ eventId: string }> }) {
+  const session = await getSession();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { eventId: eventIdStr } = await params;
+  const eventId = parseInt(eventIdStr, 10);
+  if (isNaN(eventId)) {
+    return NextResponse.json({ error: "Invalid event ID" }, { status: 400 });
+  }
+
+  const q = new URL(req.url).searchParams.get("q")?.trim().replace(/_/g, " ") ?? "";
+
+  const users = await prisma.user.findMany({
+    where: {
+      ...(q ? { name: { contains: q, mode: "insensitive" } } : {}),
+      OR: [
+        { communityPosts: { some: { eventId, status: PostStatus.APPROVED } } },
+        {
+          communityComments: {
+            some: { post: { eventId }, status: PostStatus.APPROVED, deletedAt: null },
+          },
+        },
+        {
+          registrations: {
+            some: {
+              eventId,
+              status: { in: [RegistrationStatus.APPROVED, RegistrationStatus.CONFIRMED, RegistrationStatus.PENDING] },
+            },
+          },
+        },
+      ],
+    },
+    select: { id: true, name: true },
+    take: 10,
+    orderBy: { name: "asc" },
+  });
+
+  return NextResponse.json({
+    users: users
+      .filter(u => u.name)
+      .map(u => ({ id: u.id, name: u.name! })),
+  });
+}

--- a/src/app/api/community/giphy/search/route.ts
+++ b/src/app/api/community/giphy/search/route.ts
@@ -1,0 +1,30 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { GiphyFetch } from "@giphy/js-fetch-api";
+import { getSession } from "@/lib/auth/session";
+
+export async function GET(req: NextRequest) {
+  const session = await getSession();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const apiKey = process.env.GIPHY_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json({ error: "Giphy not configured" }, { status: 503 });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const q = searchParams.get("q")?.trim();
+  const limit = Math.min(Number(searchParams.get("limit") ?? "20"), 25);
+
+  try {
+    const gf = new GiphyFetch(apiKey);
+    const { data } = q
+      ? await gf.search(q, { limit, rating: "g" })
+      : await gf.trending({ limit, rating: "g" });
+    return NextResponse.json({ gifs: data }, { status: 200 });
+  } catch (error) {
+    console.error("Giphy search error:", error);
+    return NextResponse.json({ error: "Giphy search failed" }, { status: 502 });
+  }
+}

--- a/src/app/api/community/media/upload/route.ts
+++ b/src/app/api/community/media/upload/route.ts
@@ -58,14 +58,23 @@ export async function POST(req: NextRequest) {
     await assertCanWriteInCommunity(actor, event);
 
     const bytes = Buffer.from(await file.arrayBuffer());
-    const processedBuffer = await sharp(bytes)
-      .rotate()
-      .resize(1600, 1600, { fit: "inside", withoutEnlargement: true })
-      .toFormat("jpeg", { quality: 82 })
-      .toBuffer();
 
-    const fileName = `community-${Date.now()}-${Math.random().toString(36).slice(2, 10)}.jpg`;
-    const uploadResult = await uploadCommunityImage(processedBuffer, event.id, actor.id, fileName);
+    let processedBuffer: Buffer;
+    let fileName: string;
+
+    if (file.type === "image/gif") {
+      processedBuffer = bytes;
+      fileName = `community-${Date.now()}-${Math.random().toString(36).slice(2, 10)}.gif`;
+    } else {
+      processedBuffer = await sharp(bytes)
+        .rotate()
+        .resize(1600, 1600, { fit: "inside", withoutEnlargement: true })
+        .toFormat("jpeg", { quality: 82 })
+        .toBuffer();
+      fileName = `community-${Date.now()}-${Math.random().toString(36).slice(2, 10)}.jpg`;
+    }
+
+    const uploadResult = await uploadCommunityImage(processedBuffer, event.id, actor.id, fileName, file.type === "image/gif" ? "image/gif" : "image/jpeg");
     const signedUrlData = await getSignedUrl(uploadResult.path, 365 * 24 * 60 * 60);
 
     return NextResponse.json(

--- a/src/app/api/community/posts/[postId]/comments/route.ts
+++ b/src/app/api/community/posts/[postId]/comments/route.ts
@@ -1,0 +1,163 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { PostStatus } from "@/generated/prisma";
+import {
+  CommunityError,
+  assertCanWriteInCommunity,
+  assertCommunityEnabled,
+  communityCommentInclude,
+  loadCommunityActor,
+  loadCommunityEvent,
+  serializeCommunityComment,
+} from "@/lib/community/server";
+import { getSession } from "@/lib/auth/session";
+import { prisma } from "@/lib/prisma/prisma";
+import { createCommunityCommentSchema, listCommunityCommentsSchema } from "@/types/schemas/community";
+
+function toErrorResponse(error: unknown, logMessage: string) {
+  if (error instanceof CommunityError) {
+    return NextResponse.json({ error: error.message }, { status: error.status });
+  }
+
+  console.error(logMessage, error);
+  return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+}
+
+function parseMentionNames(content: string | null | undefined): string[] {
+  if (!content) return [];
+  const matches = content.match(/@(\S+)/g) ?? [];
+  return matches.map(m => m.slice(1).replace(/_/g, " "));
+}
+
+async function buildMentionedUsersMap(userIds: string[]): Promise<Map<string, { id: string; name: string }>> {
+  if (userIds.length === 0) return new Map();
+  const users = await prisma.user.findMany({
+    where: { id: { in: userIds } },
+    select: { id: true, name: true },
+  });
+  return new Map(users.map(u => [u.id, { id: u.id, name: u.name ?? "User" }]));
+}
+
+export async function GET(req: NextRequest, { params }: { params: Promise<{ postId: string }> }) {
+  try {
+    const { postId } = await params;
+    const searchParams = Object.fromEntries(new URL(req.url).searchParams);
+    const parsed = listCommunityCommentsSchema.safeParse(searchParams);
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.issues }, { status: 422 });
+    }
+
+    const post = await prisma.communityPost.findUnique({
+      where: { id: postId },
+      select: { id: true, eventId: true, status: true },
+    });
+
+    if (!post || post.status === PostStatus.DELETED) {
+      return NextResponse.json({ error: "Post not found" }, { status: 404 });
+    }
+
+    const event = await loadCommunityEvent(post.eventId);
+    assertCommunityEnabled(event);
+
+    const comments = await prisma.communityComment.findMany({
+      where: {
+        postId,
+        status: PostStatus.APPROVED,
+        deletedAt: null,
+      },
+      include: communityCommentInclude,
+      orderBy: { createdAt: "asc" },
+      take: parsed.data.limit + 1,
+      ...(parsed.data.cursor
+        ? { cursor: { id: parsed.data.cursor }, skip: 1 }
+        : {}),
+    });
+
+    const hasMore = comments.length > parsed.data.limit;
+    const page = hasMore ? comments.slice(0, parsed.data.limit) : comments;
+
+    const allMentionedIds = [...new Set(page.flatMap(c => c.mentionedUserIds))];
+    const mentionedUsersById = await buildMentionedUsersMap(allMentionedIds);
+
+    return NextResponse.json(
+      {
+        comments: page.map(c => serializeCommunityComment(c, mentionedUsersById)),
+        nextCursor: hasMore ? page[page.length - 1]?.id ?? null : null,
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    return toErrorResponse(error, "Error listing community comments:");
+  }
+}
+
+export async function POST(req: NextRequest, { params }: { params: Promise<{ postId: string }> }) {
+  try {
+    const { postId } = await params;
+
+    const session = await getSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await req.json();
+    const parsed = createCommunityCommentSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.issues }, { status: 422 });
+    }
+
+    const post = await prisma.communityPost.findUnique({
+      where: { id: postId },
+      select: { id: true, eventId: true, status: true },
+    });
+
+    if (!post || post.status === PostStatus.DELETED) {
+      return NextResponse.json({ error: "Post not found" }, { status: 404 });
+    }
+
+    const actor = await loadCommunityActor(session.user.id);
+    if (!actor) {
+      return NextResponse.json({ error: "User not found" }, { status: 403 });
+    }
+
+    const event = await loadCommunityEvent(post.eventId);
+    assertCommunityEnabled(event);
+    await assertCanWriteInCommunity(actor, event);
+
+    const mentionNames = parseMentionNames(parsed.data.content);
+    let mentionedUserIds = parsed.data.mentionedUserIds;
+    if (mentionNames.length > 0) {
+      const resolved = await prisma.user.findMany({
+        where: { name: { in: mentionNames } },
+        select: { id: true, name: true },
+      });
+      mentionedUserIds = [...new Set([...mentionedUserIds, ...resolved.map(u => u.id)])];
+    }
+
+    const commentPending = event.communityModerated && event.communityModerateComments;
+
+    const comment = await prisma.communityComment.create({
+      data: {
+        postId,
+        authorId: actor.id,
+        content: parsed.data.content || null,
+        imageUrls: parsed.data.imageUrls,
+        gifUrl: parsed.data.gifUrl || null,
+        mentionedUserIds,
+        status: commentPending ? PostStatus.PENDING : PostStatus.APPROVED,
+      },
+      include: communityCommentInclude,
+    });
+
+    const mentionedUsersById = await buildMentionedUsersMap(mentionedUserIds);
+
+    return NextResponse.json(
+      {
+        comment: serializeCommunityComment(comment, mentionedUsersById),
+        pending: comment.status === PostStatus.PENDING,
+      },
+      { status: 201 },
+    );
+  } catch (error) {
+    return toErrorResponse(error, "Error creating community comment:");
+  }
+}

--- a/src/app/api/community/posts/[postId]/react/route.ts
+++ b/src/app/api/community/posts/[postId]/react/route.ts
@@ -58,6 +58,7 @@ export async function POST(
             communityEnabled: true,
             communityOpenAfterEnd: true,
             communityModerated: true,
+            communityModerateComments: true,
             communityAttendeesOnly: true,
           },
         },

--- a/src/app/api/community/posts/route.test.ts
+++ b/src/app/api/community/posts/route.test.ts
@@ -5,6 +5,7 @@ vi.mock("@/lib/prisma/prisma", () => ({
   prisma: {
     user: {
       findUnique: vi.fn(),
+      findMany: vi.fn(),
     },
     event: {
       findUnique: vi.fn(),
@@ -29,6 +30,7 @@ import { getSession } from "@/lib/auth/session";
 
 const mockedGetSession = getSession as unknown as ReturnType<typeof vi.fn>;
 const mockedFindUser = prisma.user.findUnique as unknown as ReturnType<typeof vi.fn>;
+const mockedFindManyUsers = prisma.user.findMany as unknown as ReturnType<typeof vi.fn>;
 const mockedFindEvent = prisma.event.findUnique as unknown as ReturnType<typeof vi.fn>;
 const mockedFindRegistration = prisma.registration.findFirst as unknown as ReturnType<typeof vi.fn>;
 const mockedFindPosts = prisma.communityPost.findMany as unknown as ReturnType<typeof vi.fn>;
@@ -54,6 +56,7 @@ function communityEvent(overrides: Record<string, unknown> = {}) {
     communityEnabled: true,
     communityOpenAfterEnd: true,
     communityModerated: true,
+    communityModerateComments: false,
     communityAttendeesOnly: true,
     ...overrides,
   };
@@ -86,6 +89,8 @@ function includedPost(overrides: Record<string, unknown> = {}) {
       { userId: "user-1", reaction: "LIKE" },
       { userId: "user-2", reaction: "LOVE" },
     ],
+    comments: [],
+    _count: { comments: 0 },
     ...overrides,
   };
 }
@@ -94,11 +99,8 @@ describe("App Router: /api/community/posts", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockedFindEvent.mockResolvedValue(communityEvent());
-    mockedFindUser.mockResolvedValue({
-      id: "user-1",
-      isAdmin: false,
-      adminProfile: null,
-    });
+    mockedFindUser.mockResolvedValue({ id: "user-1", isAdmin: false, adminProfile: null });
+    mockedFindManyUsers.mockResolvedValue([]); // mention map: no mentions in test posts
   });
 
   describe("GET", () => {

--- a/src/app/api/community/posts/route.ts
+++ b/src/app/api/community/posts/route.ts
@@ -4,6 +4,7 @@ import {
   CommunityError,
   assertCanWriteInCommunity,
   assertCommunityEnabled,
+  buildMentionMapForPosts,
   communityPostInclude,
   deriveCommunityPostTags,
   loadCommunityActor,
@@ -58,9 +59,11 @@ export async function GET(req: NextRequest) {
     const hasMore = posts.length > parsed.data.limit;
     const page = hasMore ? posts.slice(0, parsed.data.limit) : posts;
 
+    const mentionedUsersById = await buildMentionMapForPosts(page);
+
     return NextResponse.json(
       {
-        posts: page.map(post => serializeCommunityPost(post, session?.user?.id)),
+        posts: page.map(post => serializeCommunityPost(post, session?.user?.id, mentionedUsersById)),
         nextCursor: hasMore ? page[page.length - 1]?.id || null : null,
       },
       { status: 200 },

--- a/src/components/admin/events/EventForm.tsx
+++ b/src/components/admin/events/EventForm.tsx
@@ -53,6 +53,7 @@ export interface InitialData {
   communityEnabled?: boolean;
   communityOpenAfterEnd?: boolean;
   communityModerated?: boolean;
+  communityModerateComments?: boolean;
   communityAttendeesOnly?: boolean;
   paymentDeadline?: string | Date | null;
   status?: "DRAFT" | "PUBLISHED" | "CANCELLED";
@@ -220,6 +221,7 @@ export default function EventForm({ initialData, onSubmit, loading: externalLoad
       communityEnabled: initialData?.communityEnabled || false,
       communityOpenAfterEnd: initialData?.communityOpenAfterEnd ?? true,
       communityModerated: initialData?.communityModerated ?? true,
+      communityModerateComments: initialData?.communityModerateComments ?? false,
       communityAttendeesOnly: initialData?.communityAttendeesOnly ?? true,
       paymentDeadline: initialData?.paymentDeadline ? new Date(initialData.paymentDeadline) : null,
       status: initialData?.status || "DRAFT",
@@ -277,6 +279,7 @@ export default function EventForm({ initialData, onSubmit, loading: externalLoad
   const watchImageUrl = watch("imageUrl");
   const watchRequiresHotel = watch("requiresHotel") as boolean | undefined;
   const watchCommunityEnabled = watch("communityEnabled") as boolean | undefined;
+  const watchCommunityModerated = watch("communityModerated") as boolean | undefined;
   const sensors = useSensors(
     useSensor(PointerSensor),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
@@ -1191,6 +1194,26 @@ export default function EventForm({ initialData, onSubmit, loading: externalLoad
                   />
                   <Typography variant="caption" display="block" color="text.secondary">
                     New posts stay pending until approved by a future moderation workflow.
+                  </Typography>
+                  <FormControlLabel
+                    sx={{ mt: 1 }}
+                    control={
+                      <Controller
+                        name="communityModerateComments"
+                        control={control}
+                        render={({ field }) => (
+                          <Switch
+                            checked={field.value}
+                            disabled={!watchCommunityEnabled || !watchCommunityModerated}
+                            onChange={event => field.onChange(event.target.checked)}
+                          />
+                        )}
+                      />
+                    }
+                    label="Also moderate comments"
+                  />
+                  <Typography variant="caption" display="block" color="text.secondary">
+                    Requires post moderation to be enabled. Comments will also need approval before appearing.
                   </Typography>
                 </Grid>
 

--- a/src/components/common/AppHeader/AppHeader.tsx
+++ b/src/components/common/AppHeader/AppHeader.tsx
@@ -12,6 +12,9 @@ import Link from "next/link";
 import { useSession } from "@/lib/auth/client";
 import { usePathname } from "next/navigation";
 
+type ProfilePictureEntry = { signedUrl: string | null; isPrimary: boolean; order: number };
+type UserProfileResponse = { profilePictures?: ProfilePictureEntry[]; image?: string | null };
+
 /**
  * AppHeader – persistent sticky navigation bar.
  *
@@ -28,6 +31,22 @@ export default function AppHeader() {
 
     const [visible, setVisible] = useState(true);
     const lastScrollY = useRef(0);
+    const [profileImageUrl, setProfileImageUrl] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (!user?.id) {
+            setProfileImageUrl(null);
+            return;
+        }
+        fetch(`/api/user?userId=${user.id}`)
+            .then(r => r.ok ? r.json() as Promise<UserProfileResponse> : null)
+            .then(data => {
+                const pics = data?.profilePictures ?? [];
+                const primary = pics.find(p => p.isPrimary) ?? pics[0] ?? null;
+                setProfileImageUrl(primary?.signedUrl ?? user.image ?? null);
+            })
+            .catch(() => null);
+    }, [user?.id, user?.image]);
 
     useEffect(() => {
         const handleScroll = () => {
@@ -122,10 +141,10 @@ export default function AppHeader() {
                             <IconButton size="small" sx={{ p: 0 }} aria-label="Go to profile">
                                 <Avatar
                                     alt={user.name ?? "Profile"}
-                                    src={user.image ?? undefined}
+                                    src={profileImageUrl ?? undefined}
                                     sx={{ width: 36, height: 36, fontSize: "0.875rem" }}
                                 >
-                                    {!user.image && initials}
+                                    {!profileImageUrl && initials}
                                 </Avatar>
                             </IconButton>
                         </Link>

--- a/src/components/events/community/CommentComposer.tsx
+++ b/src/components/events/community/CommentComposer.tsx
@@ -1,0 +1,355 @@
+"use client";
+
+import { type ChangeEvent, useEffect, useRef, useState } from "react";
+import {
+  Box,
+  CircularProgress,
+  IconButton,
+  List,
+  ListItemButton,
+  ListItemText,
+  Paper,
+  Popover,
+  Popper,
+  Stack,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import { AddPhotoAlternate, Gif, Send } from "@mui/icons-material";
+import GiphyPicker from "./GiphyPicker";
+import type { CommunityCommentView } from "./types";
+
+interface CommentComposerProps {
+  postId: string;
+  eventId: number;
+  disabled?: boolean;
+  prefillRequest?: { value: string; seq: number } | null;
+  onCommentCreated: (comment: CommunityCommentView, pending: boolean) => void;
+}
+
+function getErrorMessage(raw: unknown, fallback: string) {
+  if (!raw || typeof raw !== "object") return fallback;
+  const payload = raw as { error?: string | Array<{ message?: string }> };
+  if (typeof payload.error === "string") return payload.error;
+  if (Array.isArray(payload.error)) return payload.error[0]?.message || fallback;
+  return fallback;
+}
+
+export default function CommentComposer({ postId, eventId, disabled, prefillRequest, onCommentCreated }: CommentComposerProps) {
+  const [content, setContent] = useState("");
+  const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement | null>(null);
+  const textFieldRef = useRef<HTMLDivElement>(null);
+
+  // Mention autocomplete
+  const [mentionQuery, setMentionQuery] = useState<string | null>(null);
+  const [mentionStart, setMentionStart] = useState(0);
+  const [suggestions, setSuggestions] = useState<{ id: string; name: string }[]>([]);
+  const [highlightIdx, setHighlightIdx] = useState(0);
+  const suggestionsOpen = mentionQuery !== null && suggestions.length > 0;
+
+  useEffect(() => {
+    if (prefillRequest) {
+      setContent(c => prefillRequest.value + c);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [prefillRequest?.seq]);
+
+  useEffect(() => {
+    if (mentionQuery === null) { setSuggestions([]); return; }
+    const t = setTimeout(async () => {
+      try {
+        const res = await fetch(`/api/community/events/${eventId}/mention-suggestions?q=${encodeURIComponent(mentionQuery)}`);
+        if (res.ok) {
+          const data = await res.json() as { users?: { id: string; name: string }[] };
+          setSuggestions(data.users ?? []);
+          setHighlightIdx(0);
+        }
+      } catch {
+        // ignore
+      }
+    }, 150);
+    return () => clearTimeout(t);
+  }, [mentionQuery, eventId]);
+
+  const detectMention = (value: string, cursorPos: number) => {
+    const before = value.slice(0, cursorPos);
+    const match = before.match(/@([^\s@]*)$/);
+    if (match) {
+      setMentionQuery(match[1]);
+      setMentionStart(cursorPos - match[0].length);
+    } else {
+      setMentionQuery(null);
+    }
+  };
+
+  const completeMention = (user: { id: string; name: string }) => {
+    const queryEnd = mentionStart + 1 + (mentionQuery?.length ?? 0);
+    const token = `@${user.name.replace(/ /g, "_")} `;
+    const newContent = content.slice(0, mentionStart) + token + content.slice(queryEnd);
+    setContent(newContent);
+    setMentionQuery(null);
+    setSuggestions([]);
+    const newCursorPos = mentionStart + token.length;
+    requestAnimationFrame(() => {
+      if (inputRef.current) {
+        inputRef.current.focus();
+        inputRef.current.setSelectionRange(newCursorPos, newCursorPos);
+      }
+    });
+  };
+
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
+  const [gifUrl, setGifUrl] = useState<string | null>(null);
+  const [gifPreviewUrl, setGifPreviewUrl] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [giphyAnchor, setGiphyAnchor] = useState<HTMLElement | null>(null);
+
+  const hasContent = content.trim().length > 0 || imageUrl !== null || gifUrl !== null;
+  const submitDisabled = disabled || loading || uploading || !hasContent;
+
+  const handleImageSelect = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    event.target.value = "";
+    if (!file) return;
+
+    setError(null);
+    setGifUrl(null);
+    setGifPreviewUrl(null);
+    setUploading(true);
+
+    try {
+      const formData = new FormData();
+      formData.append("eventId", String(eventId));
+      formData.append("file", file);
+
+      const res = await fetch("/api/community/media/upload", { method: "POST", body: formData });
+      const payload = (await res.json().catch(() => null)) as { url?: string; error?: unknown } | null;
+
+      if (!res.ok || !payload?.url) {
+        throw new Error(getErrorMessage(payload, "Failed to upload image"));
+      }
+
+      setImageUrl(payload.url);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to upload image");
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const handleGifSelect = (full: string, preview: string) => {
+    setGifUrl(full);
+    setGifPreviewUrl(preview);
+    setImageUrl(null);
+    setGiphyAnchor(null);
+  };
+
+  const handleSubmit = async () => {
+    if (submitDisabled) return;
+    setError(null);
+    setLoading(true);
+
+    try {
+      const res = await fetch(`/api/community/posts/${postId}/comments`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          content: content.trim() || undefined,
+          imageUrls: imageUrl ? [imageUrl] : [],
+          gifUrl: gifUrl || undefined,
+        }),
+      });
+      const payload = (await res.json().catch(() => null)) as {
+        comment?: CommunityCommentView;
+        pending?: boolean;
+        error?: unknown;
+      } | null;
+
+      if (!res.ok || !payload?.comment) {
+        throw new Error(getErrorMessage(payload, "Failed to post comment"));
+      }
+
+      onCommentCreated(payload.comment, Boolean(payload.pending));
+      setContent("");
+      setImageUrl(null);
+      setGifUrl(null);
+      setGifPreviewUrl(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to post comment");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const attachment = imageUrl ?? gifPreviewUrl;
+
+  return (
+    <Box>
+      {error ? (
+        <Typography variant="caption" color="error" display="block" sx={{ mb: 0.5 }}>
+          {error}
+        </Typography>
+      ) : null}
+
+      {attachment ? (
+        <Box
+          sx={{
+            position: "relative",
+            width: 120,
+            aspectRatio: "4 / 3",
+            mb: 1,
+            borderRadius: 1,
+            overflow: "hidden",
+            bgcolor: "grey.100",
+          }}
+        >
+          <Box
+            component="img"
+            src={attachment}
+            alt="Attachment preview"
+            sx={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }}
+          />
+          <IconButton
+            size="small"
+            color="error"
+            onClick={() => { setImageUrl(null); setGifUrl(null); setGifPreviewUrl(null); }}
+            sx={{ position: "absolute", top: 2, right: 2, bgcolor: "background.paper", p: 0.25 }}
+            aria-label="Remove attachment"
+          >
+            ×
+          </IconButton>
+        </Box>
+      ) : null}
+
+      <Stack direction="row" spacing={1} alignItems="center">
+        <Box ref={textFieldRef} sx={{ flex: 1, minWidth: 0 }}>
+          <TextField
+            fullWidth
+            size="small"
+            placeholder="Add a comment…"
+            value={content}
+            inputRef={inputRef}
+            onChange={e => {
+              const el = e.target as HTMLInputElement | HTMLTextAreaElement;
+              setContent(el.value);
+              detectMention(el.value, el.selectionStart ?? el.value.length);
+            }}
+            disabled={disabled}
+            onKeyDown={e => {
+              if (suggestionsOpen) {
+                if (e.key === "ArrowDown") {
+                  e.preventDefault();
+                  setHighlightIdx(i => Math.min(i + 1, suggestions.length - 1));
+                  return;
+                }
+                if (e.key === "ArrowUp") {
+                  e.preventDefault();
+                  setHighlightIdx(i => Math.max(i - 1, 0));
+                  return;
+                }
+                if ((e.key === "Tab" || e.key === "Enter") && suggestions[highlightIdx]) {
+                  e.preventDefault();
+                  completeMention(suggestions[highlightIdx]);
+                  return;
+                }
+                if (e.key === "Escape") {
+                  setMentionQuery(null);
+                  setSuggestions([]);
+                  return;
+                }
+              }
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault();
+                void handleSubmit();
+              }
+            }}
+            multiline
+            maxRows={4}
+          />
+        </Box>
+
+        <Tooltip title={uploading ? "Uploading…" : "Attach image or GIF"}>
+          <span>
+            <IconButton
+              component="label"
+              size="small"
+              color="primary"
+              disabled={disabled || uploading}
+              aria-label="Attach image or own GIF"
+            >
+              {uploading ? <CircularProgress size={18} /> : <AddPhotoAlternate fontSize="small" />}
+              <input type="file" hidden accept="image/*,image/gif" onChange={handleImageSelect} />
+            </IconButton>
+          </span>
+        </Tooltip>
+
+        <Tooltip title="Search Giphy">
+          <span>
+            <IconButton
+              size="small"
+              color="primary"
+              disabled={disabled}
+              aria-label="Search Giphy"
+              onClick={e => setGiphyAnchor(e.currentTarget)}
+            >
+              <Gif fontSize="small" />
+            </IconButton>
+          </span>
+        </Tooltip>
+
+        <Tooltip title="Send">
+          <span>
+            <IconButton
+              size="small"
+              color="primary"
+              disabled={submitDisabled}
+              aria-label="Send comment"
+              onClick={() => void handleSubmit()}
+            >
+              {loading ? <CircularProgress size={18} /> : <Send fontSize="small" />}
+            </IconButton>
+          </span>
+        </Tooltip>
+      </Stack>
+
+      <Popper
+        open={suggestionsOpen}
+        anchorEl={textFieldRef.current}
+        placement="top-start"
+        style={{ zIndex: 1400 }}
+      >
+        <Paper elevation={4} sx={{ maxHeight: 220, overflowY: "auto", minWidth: 200 }}>
+          <List dense disablePadding>
+            {suggestions.map((user, i) => (
+              <ListItemButton
+                key={user.id}
+                selected={i === highlightIdx}
+                onMouseDown={e => { e.preventDefault(); completeMention(user); }}
+                onMouseEnter={() => setHighlightIdx(i)}
+              >
+                <ListItemText
+                  primary={`@${user.name}`}
+                  slotProps={{ primary: { variant: "body2" } }}
+                />
+              </ListItemButton>
+            ))}
+          </List>
+        </Paper>
+      </Popper>
+
+      <Popover
+        open={Boolean(giphyAnchor)}
+        anchorEl={giphyAnchor}
+        onClose={() => setGiphyAnchor(null)}
+        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+      >
+        <Box sx={{ p: 1.5 }}>
+          <GiphyPicker onSelect={handleGifSelect} />
+        </Box>
+      </Popover>
+    </Box>
+  );
+}

--- a/src/components/events/community/CommentList.tsx
+++ b/src/components/events/community/CommentList.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Avatar,
+  Box,
+  Button,
+  CircularProgress,
+  Divider,
+  IconButton,
+  Link as MuiLink,
+  Stack,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import { Delete, Reply } from "@mui/icons-material";
+import NextLink from "next/link";
+import CommentComposer from "./CommentComposer";
+import type { CommunityCommentView } from "./types";
+
+const INITIAL_VISIBLE = 2;
+const LOAD_MORE_STEP = 5;
+
+function initials(name: string) {
+  return name
+    .split(" ")
+    .filter(Boolean)
+    .map(part => part[0])
+    .slice(0, 2)
+    .join("")
+    .toUpperCase();
+}
+
+function renderCommentText(text: string, mentionedUsers: { id: string; name: string }[]) {
+  const parts = text.split(/(@\S+)/g);
+  return parts.map((part, i) => {
+    if (!part.startsWith("@")) return part;
+    const token = part.slice(1);
+    const nameToMatch = token.replace(/_/g, " ");
+    const user = mentionedUsers.find(u => u.name === nameToMatch || u.name.replace(/ /g, "_") === token);
+    if (user) {
+      return (
+        <MuiLink
+          key={i}
+          component={NextLink}
+          href={`/profile/${user.id}`}
+          fontWeight={700}
+          underline="hover"
+        >
+          @{user.name}
+        </MuiLink>
+      );
+    }
+    return <strong key={i}>{part}</strong>;
+  });
+}
+
+interface CommentListProps {
+  postId: string;
+  eventId: number;
+  initialComments: CommunityCommentView[];
+  totalCount: number;
+  currentUserId?: string | null;
+  canDelete: boolean;
+  composerDisabled?: boolean;
+}
+
+export default function CommentList({
+  postId,
+  eventId,
+  initialComments,
+  totalCount,
+  currentUserId,
+  canDelete,
+  composerDisabled,
+}: CommentListProps) {
+  const [comments, setComments] = useState<CommunityCommentView[]>(initialComments);
+  const [visibleCount, setVisibleCount] = useState(INITIAL_VISIBLE);
+  const [nextCursor, setNextCursor] = useState<string | null>(
+    totalCount > INITIAL_VISIBLE ? (initialComments[initialComments.length - 1]?.id ?? null) : null,
+  );
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [displayedTotal, setDisplayedTotal] = useState(totalCount);
+  const [prefillRequest, setPrefillRequest] = useState<{ value: string; seq: number } | null>(null);
+
+  const handleCommentCreated = (comment: CommunityCommentView, pending: boolean) => {
+    if (!pending) {
+      setComments(current => [...current, comment]);
+      setVisibleCount(v => v + 1);
+      setDisplayedTotal(t => t + 1);
+    }
+  };
+
+  const handleReply = (authorName: string) => {
+    const mention = `@${authorName.replace(/ /g, "_")} `;
+    setPrefillRequest(prev => ({ value: mention, seq: (prev?.seq ?? 0) + 1 }));
+  };
+
+  const handleLoadMore = async () => {
+    setLoadingMore(true);
+    try {
+      const params = new URLSearchParams({ limit: String(LOAD_MORE_STEP) });
+      if (nextCursor) params.set("cursor", nextCursor);
+
+      const res = await fetch(`/api/community/posts/${postId}/comments?${params.toString()}`);
+      const payload = (await res.json().catch(() => null)) as {
+        comments?: CommunityCommentView[];
+        nextCursor?: string | null;
+      } | null;
+
+      if (!res.ok || !payload?.comments) return;
+
+      const existingIds = new Set(comments.map(c => c.id));
+      const fresh = payload.comments.filter(c => !existingIds.has(c.id));
+      setComments(current => [...current, ...fresh]);
+      setVisibleCount(v => v + fresh.length);
+      setNextCursor(payload.nextCursor ?? null);
+    } finally {
+      setLoadingMore(false);
+    }
+  };
+
+  const handleDelete = async (commentId: string) => {
+    setDeletingId(commentId);
+    try {
+      const res = await fetch(`/api/community/comments/${commentId}`, { method: "DELETE" });
+      if (res.ok) {
+        setComments(current => current.filter(c => c.id !== commentId));
+        setVisibleCount(v => Math.max(0, v - 1));
+        setDisplayedTotal(t => Math.max(0, t - 1));
+      }
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  const visible = comments.slice(0, visibleCount);
+  const remaining = displayedTotal - visibleCount;
+  const canShowMore = remaining > 0 || (nextCursor !== null && visibleCount >= comments.length);
+
+  return (
+    <Box>
+      <Divider sx={{ mb: 1.5 }} />
+
+      {visible.length > 0 ? (
+        <Stack spacing={1.5} sx={{ mb: 1.5 }}>
+          {visible.map(comment => {
+            const createdAt = new Intl.DateTimeFormat("en-US", {
+              dateStyle: "medium",
+              timeStyle: "short",
+            }).format(new Date(comment.createdAt));
+
+            return (
+              <Stack key={comment.id} direction="row" spacing={1} alignItems="flex-start">
+                <NextLink href={`/profile/${comment.author.id}`} style={{ textDecoration: "none", flexShrink: 0 }}>
+                  <Avatar
+                    src={comment.author.imageUrl || undefined}
+                    alt={comment.author.name}
+                    sx={{ width: 28, height: 28, fontSize: "0.7rem", cursor: "pointer", "&:hover": { opacity: 0.8 } }}
+                  >
+                    {comment.author.imageUrl ? null : initials(comment.author.name) || "?"}
+                  </Avatar>
+                </NextLink>
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <Stack direction="row" spacing={0.5} alignItems="baseline" flexWrap="wrap" useFlexGap>
+                    <MuiLink
+                      component={NextLink}
+                      href={`/profile/${comment.author.id}`}
+                      underline="hover"
+                      color="text.primary"
+                    >
+                      <Typography variant="caption" fontWeight={700}>
+                        {comment.author.name}
+                      </Typography>
+                    </MuiLink>
+                    <Typography variant="caption" color="text.secondary">
+                      {createdAt}
+                    </Typography>
+                  </Stack>
+                  {comment.content ? (
+                    <Typography variant="body2" sx={{ whiteSpace: "pre-wrap", overflowWrap: "anywhere" }}>
+                      {renderCommentText(comment.content, comment.mentionedUsers)}
+                    </Typography>
+                  ) : null}
+                  {comment.imageUrls.length > 0 ? (
+                    <Box
+                      component="img"
+                      src={comment.imageUrls[0]}
+                      alt="Comment attachment"
+                      sx={{ mt: 0.5, maxWidth: 200, maxHeight: 200, borderRadius: 1, display: "block" }}
+                    />
+                  ) : null}
+                  {comment.gifUrl ? (
+                    <Box
+                      component="img"
+                      src={comment.gifUrl}
+                      alt="GIF"
+                      sx={{ mt: 0.5, maxWidth: 200, maxHeight: 200, borderRadius: 1, display: "block" }}
+                    />
+                  ) : null}
+                  {!composerDisabled ? (
+                    <Button
+                      size="small"
+                      variant="text"
+                      startIcon={<Reply sx={{ fontSize: "0.85rem" }} />}
+                      onClick={() => handleReply(comment.author.name)}
+                      sx={{ mt: 0.25, minWidth: 0, p: "2px 6px", fontSize: "0.7rem", textTransform: "none", color: "text.secondary" }}
+                    >
+                      Reply
+                    </Button>
+                  ) : null}
+                </Box>
+                {canDelete ? (
+                  <Tooltip title="Delete comment">
+                    <span>
+                      <IconButton
+                        size="small"
+                        color="error"
+                        disabled={deletingId === comment.id}
+                        onClick={() => void handleDelete(comment.id)}
+                        aria-label="Delete comment"
+                        sx={{ flexShrink: 0 }}
+                      >
+                        {deletingId === comment.id
+                          ? <CircularProgress size={14} />
+                          : <Delete sx={{ fontSize: "0.9rem" }} />}
+                      </IconButton>
+                    </span>
+                  </Tooltip>
+                ) : null}
+              </Stack>
+            );
+          })}
+        </Stack>
+      ) : null}
+
+      {canShowMore ? (
+        <Button
+          size="small"
+          variant="text"
+          disabled={loadingMore}
+          onClick={() => void handleLoadMore()}
+          sx={{ mb: 1, textTransform: "none" }}
+        >
+          {loadingMore
+            ? <CircularProgress size={14} />
+            : `more comments (${remaining})`}
+        </Button>
+      ) : null}
+
+      {!composerDisabled ? (
+        <CommentComposer
+          postId={postId}
+          eventId={eventId}
+          disabled={composerDisabled}
+          prefillRequest={prefillRequest}
+          onCommentCreated={handleCommentCreated}
+        />
+      ) : null}
+    </Box>
+  );
+}

--- a/src/components/events/community/CommunityPostCard.tsx
+++ b/src/components/events/community/CommunityPostCard.tsx
@@ -18,6 +18,7 @@ import { Celebration, CheckCircle, Delete, Favorite, Lightbulb, Link as LinkIcon
 import Image from "next/image";
 import NextLink from "next/link";
 import type { ReactNode } from "react";
+import CommentList from "./CommentList";
 import type { CommunityPostView, CommunityReactionKey } from "./types";
 
 const reactionConfig: Array<{
@@ -65,6 +66,8 @@ interface CommunityPostCardProps {
   deleteDisabled?: boolean;
   moderateDisabled?: boolean;
   reactionDisabled?: boolean;
+  currentUserId?: string | null;
+  composerDisabled?: boolean;
   onDelete: (postId: string) => void;
   onModerate?: (postId: string, action: ModerateAction) => void;
   onReact: (postId: string, reaction: CommunityReactionKey) => void;
@@ -78,6 +81,8 @@ export default function CommunityPostCard({
   deleteDisabled,
   moderateDisabled,
   reactionDisabled,
+  currentUserId,
+  composerDisabled,
   onDelete,
   onModerate,
   onReact,
@@ -289,6 +294,16 @@ export default function CommunityPostCard({
             );
           })}
         </Stack>
+
+        <CommentList
+          postId={post.id}
+          eventId={post.eventId}
+          initialComments={post.comments}
+          totalCount={post.commentCount}
+          currentUserId={currentUserId}
+          canDelete={canDelete}
+          composerDisabled={composerDisabled}
+        />
       </Stack>
     </Paper>
   );

--- a/src/components/events/community/CommunitySection.tsx
+++ b/src/components/events/community/CommunitySection.tsx
@@ -287,6 +287,8 @@ export default function CommunitySection({
                 deleteDisabled={!currentUserId || actionPostId === post.id}
                 moderateDisabled={Boolean(moderatingPostId)}
                 reactionDisabled={!currentUserId || Boolean(composerDisabledReason)}
+                currentUserId={currentUserId}
+                composerDisabled={Boolean(composerDisabledReason)}
                 onDelete={handleDelete}
                 onModerate={canModerate ? handleModerate : undefined}
                 onReact={handleReact}

--- a/src/components/events/community/GiphyPicker.tsx
+++ b/src/components/events/community/GiphyPicker.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import {
+  Box,
+  CircularProgress,
+  InputAdornment,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { Search } from "@mui/icons-material";
+import type { IGif } from "@giphy/js-types";
+
+interface GiphyPickerProps {
+  onSelect: (gifUrl: string, previewUrl: string) => void;
+}
+
+export default function GiphyPicker({ onSelect }: GiphyPickerProps) {
+  const [query, setQuery] = useState("");
+  const [gifs, setGifs] = useState<IGif[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+
+    if (!query.trim()) {
+      setLoading(true);
+      setError(null);
+      fetch("/api/community/giphy/search?limit=20")
+        .then(r => r.json())
+        .then((payload: { gifs?: IGif[] }) => { setGifs(payload.gifs ?? []); })
+        .catch(() => setGifs([]))
+        .finally(() => setLoading(false));
+      return;
+    }
+
+    debounceRef.current = setTimeout(async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch(
+          `/api/community/giphy/search?q=${encodeURIComponent(query)}&limit=20`,
+        );
+        const payload = (await res.json().catch(() => null)) as { gifs?: IGif[]; error?: string } | null;
+        if (!res.ok || !payload?.gifs) {
+          throw new Error(payload?.error ?? "Failed to search GIFs");
+        }
+        setGifs(payload.gifs);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to search GIFs");
+        setGifs([]);
+      } finally {
+        setLoading(false);
+      }
+    }, 500);
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [query]);
+
+  return (
+    <Box sx={{ width: 320 }}>
+      <TextField
+        fullWidth
+        size="small"
+        placeholder="Search Giphy..."
+        value={query}
+        onChange={e => setQuery(e.target.value)}
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              {loading ? <CircularProgress size={16} /> : <Search fontSize="small" />}
+            </InputAdornment>
+          ),
+        }}
+        sx={{ mb: 1 }}
+      />
+
+      {error ? (
+        <Typography variant="caption" color="error" display="block" sx={{ mb: 1 }}>
+          {error}
+        </Typography>
+      ) : null}
+
+      {gifs.length > 0 ? (
+        <Box
+          sx={{
+            display: "grid",
+            gridTemplateColumns: "repeat(2, 1fr)",
+            gap: 0.5,
+            maxHeight: 240,
+            overflowY: "auto",
+          }}
+        >
+          {gifs.map(gif => {
+            const preview = gif.images.fixed_height_small?.url ?? gif.images.fixed_height?.url ?? "";
+            const full = gif.images.original?.url ?? preview;
+            return (
+              <Box
+                key={gif.id}
+                component="img"
+                src={preview}
+                alt={gif.title}
+                onClick={() => onSelect(full, preview)}
+                sx={{
+                  width: "100%",
+                  aspectRatio: "4 / 3",
+                  objectFit: "cover",
+                  cursor: "pointer",
+                  borderRadius: 1,
+                  "&:hover": { opacity: 0.8 },
+                }}
+              />
+            );
+          })}
+        </Box>
+      ) : !loading && query.trim() ? (
+        <Typography variant="caption" color="text.secondary">No GIFs found.</Typography>
+      ) : null}
+
+      <Typography variant="caption" color="text.secondary" display="block" sx={{ mt: 1, textAlign: "right" }}>
+        Powered by GIPHY
+      </Typography>
+    </Box>
+  );
+}

--- a/src/components/events/community/types.ts
+++ b/src/components/events/community/types.ts
@@ -9,6 +9,23 @@ export type CommunityFeedbackItem = {
 
 export type CommunityReactionKey = "LIKE" | "LOVE" | "CELEBRATE" | "HELPFUL";
 
+export type CommunityCommentView = {
+  id: string;
+  postId: string;
+  authorId: string;
+  content: string | null;
+  imageUrls: string[];
+  gifUrl: string | null;
+  status: "PENDING" | "APPROVED" | "REJECTED" | "DELETED";
+  createdAt: string;
+  author: {
+    id: string;
+    name: string;
+    imageUrl: string | null;
+  };
+  mentionedUsers: { id: string; name: string }[];
+};
+
 export type CommunityPostView = {
   id: string;
   eventId: number;
@@ -32,4 +49,6 @@ export type CommunityPostView = {
   };
   reactions: Record<CommunityReactionKey, number>;
   viewerReactions: string[];
+  commentCount: number;
+  comments: CommunityCommentView[];
 };

--- a/src/lib/community/server.ts
+++ b/src/lib/community/server.ts
@@ -1,6 +1,7 @@
 import type { Prisma } from "@/generated/prisma";
 import { CommunityFeedbackType, CommunityPostType, ModerationAction, PostStatus } from "@/generated/prisma";
 import { prisma } from "@/lib/prisma/prisma";
+import type { CommunityCommentView } from "@/components/events/community/types";
 
 export const COMMUNITY_REACTIONS = ["LIKE", "LOVE", "CELEBRATE", "HELPFUL"] as const;
 
@@ -38,6 +39,32 @@ export class CommunityError extends Error {
   }
 }
 
+export const communityCommentInclude = {
+  author: {
+    select: {
+      id: true,
+      name: true,
+      image: true,
+      profilePictures: {
+        orderBy: [
+          { isPrimary: "desc" as const },
+          { order: "asc" as const },
+          { createdAt: "desc" as const },
+        ],
+        take: 1,
+        select: {
+          signedUrl: true,
+          isPrimary: true,
+        },
+      },
+    },
+  },
+} satisfies Prisma.CommunityCommentInclude;
+
+export type CommunityCommentWithInclude = Prisma.CommunityCommentGetPayload<{
+  include: typeof communityCommentInclude;
+}>;
+
 export const communityPostInclude = {
   author: {
     select: {
@@ -64,6 +91,39 @@ export const communityPostInclude = {
       reaction: true,
     },
   },
+  comments: {
+    where: { status: PostStatus.APPROVED, deletedAt: null },
+    orderBy: { createdAt: "asc" as const },
+    take: 2,
+    include: {
+      author: {
+        select: {
+          id: true,
+          name: true,
+          image: true,
+          profilePictures: {
+            orderBy: [
+              { isPrimary: "desc" as const },
+              { order: "asc" as const },
+              { createdAt: "desc" as const },
+            ],
+            take: 1,
+            select: {
+              signedUrl: true,
+              isPrimary: true,
+            },
+          },
+        },
+      },
+    },
+  },
+  _count: {
+    select: {
+      comments: {
+        where: { status: PostStatus.APPROVED, deletedAt: null },
+      },
+    },
+  },
 } satisfies Prisma.CommunityPostInclude;
 
 export type CommunityPostWithInclude = Prisma.CommunityPostGetPayload<{
@@ -83,6 +143,7 @@ export type CommunityEventAccess = {
   communityEnabled: boolean;
   communityOpenAfterEnd: boolean;
   communityModerated: boolean;
+  communityModerateComments: boolean;
   communityAttendeesOnly: boolean;
 };
 
@@ -175,6 +236,7 @@ export async function loadCommunityEvent(eventId: number): Promise<CommunityEven
       communityEnabled: true,
       communityOpenAfterEnd: true,
       communityModerated: true,
+      communityModerateComments: true,
       communityAttendeesOnly: true,
     },
   });
@@ -236,7 +298,47 @@ export function assertCanDeletePost(
   throw new CommunityError(403, "You cannot delete this post");
 }
 
-export function serializeCommunityPost(post: CommunityPostWithInclude, viewerUserId?: string | null) {
+export async function buildMentionMapForPosts(
+  posts: { comments: { mentionedUserIds: string[] }[] }[],
+): Promise<Map<string, { id: string; name: string }>> {
+  const allIds = [...new Set(posts.flatMap(p => p.comments.flatMap(c => c.mentionedUserIds)))];
+  if (allIds.length === 0) return new Map();
+  const users = await prisma.user.findMany({
+    where: { id: { in: allIds } },
+    select: { id: true, name: true },
+  });
+  return new Map(users.map(u => [u.id, { id: u.id, name: u.name ?? "User" }]));
+}
+
+export function serializeCommunityComment(
+  comment: CommunityCommentWithInclude,
+  mentionedUsersById?: Map<string, { id: string; name: string }>,
+): CommunityCommentView {
+  return {
+    id: comment.id,
+    postId: comment.postId,
+    authorId: comment.authorId,
+    content: comment.content,
+    imageUrls: comment.imageUrls,
+    gifUrl: comment.gifUrl,
+    status: comment.status,
+    createdAt: comment.createdAt.toISOString(),
+    author: {
+      id: comment.author.id,
+      name: comment.author.name || "Attendee",
+      imageUrl: comment.author.profilePictures[0]?.signedUrl || comment.author.image || null,
+    },
+    mentionedUsers: comment.mentionedUserIds
+      .map(id => mentionedUsersById?.get(id))
+      .filter((u): u is { id: string; name: string } => u !== undefined),
+  };
+}
+
+export function serializeCommunityPost(
+  post: CommunityPostWithInclude,
+  viewerUserId?: string | null,
+  mentionedUsersById?: Map<string, { id: string; name: string }>,
+) {
   const feedbacks = normalizeCommunityFeedbackEntries(post.feedbackEntries, {
     content: post.content,
     feedbackRating: post.feedbackRating,
@@ -281,6 +383,8 @@ export function serializeCommunityPost(post: CommunityPostWithInclude, viewerUse
     },
     reactions: reactionCounts,
     viewerReactions,
+    commentCount: post._count.comments,
+    comments: post.comments.map(c => serializeCommunityComment(c as CommunityCommentWithInclude, mentionedUsersById)),
   };
 }
 

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -44,13 +44,13 @@ export async function uploadEventImage(file: Buffer, fileName: string) {
     return data;
 }
 
-export async function uploadCommunityImage(file: Buffer, eventId: number, userId: string, fileName: string) {
+export async function uploadCommunityImage(file: Buffer, eventId: number, userId: string, fileName: string, contentType: string = "image/jpeg") {
     const { data, error } = await getSupabaseClient().storage
         .from(process.env.SUPABASE_BUCKET_ID)
         .upload(`community/${eventId}/${userId}/${fileName}`, file, {
             cacheControl: '3600',
             upsert: false,
-            contentType: 'image/jpeg'
+            contentType,
     });
 
     if(error) throw error;

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -23,5 +23,7 @@ declare namespace NodeJS {
         SUPABASE_BUCKET_ID: string;
 
         SMTP_FROM?: string;
+
+        GIPHY_API_KEY?: string;
     }
 }

--- a/src/types/schemas/community.ts
+++ b/src/types/schemas/community.ts
@@ -114,7 +114,24 @@ export const bulkModerateCommunityPostsSchema = z.object({
   reason: z.string().trim().max(500).optional(),
 });
 
+export const createCommunityCommentSchema = z
+  .object({
+    content: z.string().trim().max(2000).optional(),
+    imageUrls: z.array(z.url()).max(1).default([]),
+    gifUrl: z.url().optional(),
+    mentionedUserIds: z.array(z.string()).default([]),
+  })
+  .refine(d => d.content?.trim() || d.imageUrls.length > 0 || d.gifUrl, {
+    message: "Comment needs content, an image, or a GIF",
+  });
+
+export const listCommunityCommentsSchema = z.object({
+  cursor: z.string().min(1).optional(),
+  limit: z.coerce.number().int().min(1).max(50).default(5),
+});
+
 export type CreateCommunityPostInput = z.infer<typeof createCommunityPostSchema>;
+export type CreateCommunityCommentInput = z.infer<typeof createCommunityCommentSchema>;
 export type CommunityFeedbackInput = z.infer<typeof communityFeedbackEntrySchema>;
 export type ModerateCommunityPostInput = z.infer<typeof moderateCommunityPostSchema>;
 export type BulkModerateCommunityPostsInput = z.infer<typeof bulkModerateCommunityPostsSchema>;

--- a/src/types/schemas/event/base.ts
+++ b/src/types/schemas/event/base.ts
@@ -246,6 +246,8 @@ export const EventBaseObject = z.object({
   communityOpenAfterEnd: z.boolean().default(true),
   /** New posts require moderation before they appear publicly */
   communityModerated: z.boolean().default(true),
+  /** Also require moderation for comments (only active when communityModerated is true) */
+  communityModerateComments: z.boolean().default(false),
   /** Restrict community writes to active attendees */
   communityAttendeesOnly: z.boolean().default(true),
   /** Fixed deadline for all payments */


### PR DESCRIPTION
… autocomplete

- CommunityComment model with soft-delete, moderation flag, mentionedUserIds
- GET/POST /api/community/posts/[postId]/comments with cursor pagination
- DELETE /api/community/comments/[commentId] (author/admin/event-owner)
- Server-side Giphy proxy; own GIF uploads bypass sharp pipeline
- @mention parsing on create → stores resolved user IDs
- GET /api/community/events/[eventId]/mention-suggestions for autocomplete
- CommentComposer with Giphy popover, image/GIF attach, @mention dropdown
- CommentList: 2 preloaded, +5 per load-more, reply prefill, mention links
- communityModerateComments event flag (requires communityModerated)
- buildMentionMapForPosts batch-fetches mentions for preloaded comments
- AppHeader avatar fetches profile picture from /api/user?userId=
- 35 tests covering routes, permissions, mention resolution, serialization

## Summary

## Testing

<!-- ventry:auto-fixes:start -->
Fixes #83
<!-- ventry:auto-fixes:end -->
